### PR TITLE
Fixes to run on new Jenkins

### DIFF
--- a/jobs/ci-run/build/buildjuju.yml
+++ b/jobs/ci-run/build/buildjuju.yml
@@ -117,6 +117,7 @@
           description: "Comma seperated list of Go Platforms to build the OCI images for"
           name: BUILD_PLATFORMS
     builders:
+      - install-go
       - set-common-variables
       - install-common-tools
       - shell: |-
@@ -160,6 +161,7 @@
           description: 'Go version used for build.'
           name: GOVERSION
     builders:
+      - install-go
       # Need to populate with which arch we're building for.
       - shell: |-
           #!/bin/bash
@@ -214,6 +216,7 @@
           description: 'Go version used for build.'
           name: GOVERSION
     builders:
+      - install-go
       # Need to populate with which arch we're building for.
       - shell: |-
           #!/bin/bash
@@ -313,6 +316,7 @@
           description: "Enable sub job to be run individually."
           name: SHORT_GIT_COMMIT
     builders:
+      - install-go
       # Need to populate with which arch we're building for.
       - shell: |-
           #!/bin/bash
@@ -364,6 +368,7 @@
           description: "Enable sub job to be run individually."
           name: SHORT_GIT_COMMIT
     builders:
+      - install-go
       # Need to populate with which arch we're building for.
       - shell: |-
           #!/bin/bash
@@ -456,6 +461,7 @@
           description: 'Go version used for build.'
           name: GOVERSION
     builders:
+      - install-go
       # Need to populate with which arch we're building for.
       - shell: |-
           #!/bin/bash
@@ -463,7 +469,6 @@
           echo "BUILD_ARCH=amd64" > build.properties
       - inject:
           properties-file: build.properties
-      - install-go
       - get-s3-source-payload
       - set-builder-description
       - shell: |-
@@ -535,6 +540,7 @@
           description: 'Go version used for build.'
           name: GOVERSION
     builders:
+      - install-go
       - shell: |-
           #!/bin/bash
           set -e
@@ -600,6 +606,7 @@
           description: 'Go version used for build.'
           name: GOVERSION
     builders:
+      - install-go
       - get-s3-source-payload
       # Need to populate with which arch we're building for.
       - shell: |-

--- a/jobs/ci-run/ci-run-master.yml
+++ b/jobs/ci-run/ci-run-master.yml
@@ -232,6 +232,7 @@
           description: 'Go version used for build.'
           name: GOVERSION
     builders:
+      - install-go
       - inject:
           properties-content: |-
             JUJU_SOURCE_CHECKOUT=${WORKSPACE}/tmp_initial_clone

--- a/jobs/ci-run/unittest/unittests.yml
+++ b/jobs/ci-run/unittest/unittests.yml
@@ -120,6 +120,7 @@
         default: ""
         description: "Go version to use for unit tests"
     builders:
+      - install-go
       # Need to populate with which arch we're building for.
       - shell: echo "BUILD_ARCH=amd64" > build.properties
       - shell: echo "TEST_TIMEOUT=${TEST_TIMEOUT}" >> build.properties
@@ -168,6 +169,7 @@
         default: ""
         description: "Go version to use for unit tests"
     builders:
+      - install-go
       # Need to populate with which arch we're building for.
       - shell: echo "BUILD_ARCH=amd64" > build.properties
       - shell: echo "TEST_TIMEOUT=${TEST_TIMEOUT}" >> build.properties
@@ -216,6 +218,7 @@
         default: ""
         description: "Go version to use for unit tests"
     builders:
+      - install-go
       # Need to populate with which arch we're building for.
       - shell: echo "BUILD_ARCH=arm64" > build.properties
       - shell: echo "TEST_TIMEOUT=${TEST_TIMEOUT}" >> build.properties
@@ -264,6 +267,7 @@
         default: ""
         description: "Go version to use for unit tests"
     builders:
+      - install-go
       # Need to populate with which arch we're building for.
       - shell: echo "BUILD_ARCH=arm64" > build.properties
       - shell: echo "TEST_TIMEOUT=${TEST_TIMEOUT}" >> build.properties
@@ -408,6 +412,7 @@
         default: ""
         description: "Go version to use for unit tests"
     builders:
+      - install-go
       # Need to populate with which arch we're building for.
       - shell: echo "BUILD_ARCH=amd64" > build.properties
       - shell: echo "TEST_TIMEOUT=${TEST_TIMEOUT}" >> build.properties
@@ -457,6 +462,7 @@
         default: ""
         description: "Go version to use for unit tests"
     builders:
+      - install-go
       # Need to populate with which arch we're building for.
       - shell: echo "BUILD_ARCH=arm64" > build.properties
       - shell: echo "TEST_TIMEOUT=${TEST_TIMEOUT}" >> build.properties

--- a/jobs/github/mergejobs.yaml
+++ b/jobs/github/mergejobs.yaml
@@ -173,6 +173,7 @@
     builders:
       - description-setter:
           description: '<a href="${ghprbPullLink}">PR #${ghprbPullId}</a>'
+      - install-go
       - shell: |-
           #!/bin/bash
           GOOS="linux"
@@ -233,6 +234,7 @@
     builders:
       - description-setter:
           description: '<a href="${ghprbPullLink}">PR #${ghprbPullId}</a>'
+      - install-go
       - inject:
           properties-content: |-
             PROJECT_DIR="github.com/juju/juju"


### PR DESCRIPTION
- Add go-builder to jobs that need go at a specific version