### PR TITLE
Use epehemeral nodes for generated integration tests

### DIFF
--- a/jobs/ci-run/integration/aws/test-expose-ec2.yml
+++ b/jobs/ci-run/integration/aws/test-expose-ec2.yml
@@ -1,6 +1,6 @@
 - job:
     name: 'test-expose-ec2'
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test Expose on EC2 Suite
     parameters:

--- a/jobs/ci-run/integration/aws/test-network-health-ec2.yml
+++ b/jobs/ci-run/integration/aws/test-network-health-ec2.yml
@@ -1,6 +1,6 @@
 - job:
     name: 'test-network-health-ec2'
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test Network Health on EC2
     parameters:

--- a/jobs/ci-run/integration/aws/test-spaces-ec2.yml
+++ b/jobs/ci-run/integration/aws/test-spaces-ec2.yml
@@ -1,6 +1,6 @@
 - job:
     name: 'test-spaces-ec2'
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test Spaces on EC2 Suite
     parameters:

--- a/jobs/ci-run/integration/gen/test-agents.yml
+++ b/jobs/ci-run/integration/gen/test-agents.yml
@@ -90,7 +90,7 @@
 
 - job:
     name: test-agents-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test agents suite on aws
     parameters:

--- a/jobs/ci-run/integration/gen/test-appdata.yml
+++ b/jobs/ci-run/integration/gen/test-appdata.yml
@@ -90,7 +90,7 @@
 
 - job:
     name: test-appdata-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test appdata suite on aws
     parameters:

--- a/jobs/ci-run/integration/gen/test-backup.yml
+++ b/jobs/ci-run/integration/gen/test-backup.yml
@@ -90,7 +90,7 @@
 
 - job:
     name: test-backup-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test backup suite on aws
     parameters:

--- a/jobs/ci-run/integration/gen/test-branches.yml
+++ b/jobs/ci-run/integration/gen/test-branches.yml
@@ -95,7 +95,7 @@
 
 - job:
     name: test-branches-test-active-branch-output-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_active_branch_output in branches suite on aws
     parameters:
@@ -191,7 +191,7 @@
 
 - job:
     name: test-branches-test-branch-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_branch in branches suite on aws
     parameters:

--- a/jobs/ci-run/integration/gen/test-charmhub.yml
+++ b/jobs/ci-run/integration/gen/test-charmhub.yml
@@ -99,7 +99,7 @@
 
 - job:
     name: test-charmhub-test-charmhub-download-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_charmhub_download in charmhub suite on aws
     parameters:
@@ -195,7 +195,7 @@
 
 - job:
     name: test-charmhub-test-charmhub-find-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_charmhub_find in charmhub suite on aws
     parameters:
@@ -291,7 +291,7 @@
 
 - job:
     name: test-charmhub-test-charmhub-info-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_charmhub_info in charmhub suite on aws
     parameters:

--- a/jobs/ci-run/integration/gen/test-controller.yml
+++ b/jobs/ci-run/integration/gen/test-controller.yml
@@ -95,7 +95,7 @@
 
 - job:
     name: test-controller-test-enable-ha-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_enable_ha in controller suite on aws
     parameters:
@@ -191,7 +191,7 @@
 
 - job:
     name: test-controller-test-mongo-memory-profile-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_mongo_memory_profile in controller suite on aws
     parameters:

--- a/jobs/ci-run/integration/gen/test-deploy.yml
+++ b/jobs/ci-run/integration/gen/test-deploy.yml
@@ -99,7 +99,7 @@
 
 - job:
     name: test-deploy-test-cmr-bundles-export-overlay-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_cmr_bundles_export_overlay in deploy suite on aws
     parameters:
@@ -195,7 +195,7 @@
 
 - job:
     name: test-deploy-test-deploy-bundles-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_deploy_bundles in deploy suite on aws
     parameters:
@@ -291,7 +291,7 @@
 
 - job:
     name: test-deploy-test-deploy-charms-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_deploy_charms in deploy suite on aws
     parameters:
@@ -387,7 +387,7 @@
 
 - job:
     name: test-deploy-test-deploy-os-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_deploy_os in deploy suite on aws
     parameters:
@@ -483,7 +483,7 @@
 
 - job:
     name: test-deploy-test-deploy-revision-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_deploy_revision in deploy suite on aws
     parameters:

--- a/jobs/ci-run/integration/gen/test-hooks.yml
+++ b/jobs/ci-run/integration/gen/test-hooks.yml
@@ -95,7 +95,7 @@
 
 - job:
     name: test-hooks-test-dispatching-script-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_dispatching_script in hooks suite on aws
     parameters:
@@ -191,7 +191,7 @@
 
 - job:
     name: test-hooks-test-start-hook-fires-after-reboot-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_start_hook_fires_after_reboot in hooks suite on aws
     parameters:

--- a/jobs/ci-run/integration/gen/test-hooktools.yml
+++ b/jobs/ci-run/integration/gen/test-hooktools.yml
@@ -90,7 +90,7 @@
 
 - job:
     name: test-hooktools-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test hooktools suite on aws
     parameters:

--- a/jobs/ci-run/integration/gen/test-machine.yml
+++ b/jobs/ci-run/integration/gen/test-machine.yml
@@ -90,7 +90,7 @@
 
 - job:
     name: test-machine-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test machine suite on aws
     parameters:

--- a/jobs/ci-run/integration/gen/test-manual.yml
+++ b/jobs/ci-run/integration/gen/test-manual.yml
@@ -95,7 +95,7 @@
 
 - job:
     name: test-manual-test-deploy-manual-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_deploy_manual in manual suite on aws
     parameters:
@@ -191,7 +191,7 @@
 
 - job:
     name: test-manual-test-spaces-manual-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_spaces_manual in manual suite on aws
     parameters:

--- a/jobs/ci-run/integration/gen/test-model.yml
+++ b/jobs/ci-run/integration/gen/test-model.yml
@@ -103,7 +103,7 @@
 
 - job:
     name: test-model-test-model-config-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_model_config in model suite on aws
     parameters:
@@ -199,7 +199,7 @@
 
 - job:
     name: test-model-test-model-metrics-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_model_metrics in model suite on aws
     parameters:
@@ -295,7 +295,7 @@
 
 - job:
     name: test-model-test-model-migration-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_model_migration in model suite on aws
     parameters:
@@ -391,7 +391,7 @@
 
 - job:
     name: test-model-test-model-multi-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_model_multi in model suite on aws
     parameters:

--- a/jobs/ci-run/integration/gen/test-network.yml
+++ b/jobs/ci-run/integration/gen/test-network.yml
@@ -90,7 +90,7 @@
 
 - job:
     name: test-network-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test network suite on aws
     parameters:

--- a/jobs/ci-run/integration/gen/test-relations.yml
+++ b/jobs/ci-run/integration/gen/test-relations.yml
@@ -99,7 +99,7 @@
 
 - job:
     name: test-relations-test-relation-data-exchange-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_relation_data_exchange in relations suite on aws
     parameters:
@@ -195,7 +195,7 @@
 
 - job:
     name: test-relations-test-relation-departing-unit-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_relation_departing_unit in relations suite on aws
     parameters:
@@ -291,7 +291,7 @@
 
 - job:
     name: test-relations-test-relation-list-app-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_relation_list_app in relations suite on aws
     parameters:

--- a/jobs/ci-run/integration/gen/test-resources.yml
+++ b/jobs/ci-run/integration/gen/test-resources.yml
@@ -95,7 +95,7 @@
 
 - job:
     name: test-resources-test-basic-resources-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_basic_resources in resources suite on aws
     parameters:
@@ -191,7 +191,7 @@
 
 - job:
     name: test-resources-test-upgrade-resources-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_upgrade_resources in resources suite on aws
     parameters:

--- a/jobs/ci-run/integration/gen/test-smoke.yml
+++ b/jobs/ci-run/integration/gen/test-smoke.yml
@@ -95,7 +95,7 @@
 
 - job:
     name: test-smoke-test-build-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_build in smoke suite on aws
     parameters:
@@ -191,7 +191,7 @@
 
 - job:
     name: test-smoke-test-deploy-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test test_deploy in smoke suite on aws
     parameters:

--- a/jobs/ci-run/integration/gen/test-unit.yml
+++ b/jobs/ci-run/integration/gen/test-unit.yml
@@ -90,7 +90,7 @@
 
 - job:
     name: test-unit-aws
-    node: integration-tests
+    node: ephemeral-focal-small-amd64
     description: |-
       Test unit suite on aws
     parameters:

--- a/jobs/z-jobs/z-clean-azure.yml
+++ b/jobs/z-jobs/z-clean-azure.yml
@@ -1,5 +1,5 @@
 - job:
-    name: 'z-clean-azure'
+    name: 'z-clean-resources-azure'
     builders:
     - get-azure-creds
     - get-azure-cleanup-scripts
@@ -23,7 +23,7 @@
           <h1>Infrastructure failure: Azure</h1>
           The following job has repeatedly failed.
           <br />
-          Please login to jenkins job <pre>`z-clean-azure`</pre> to find out why
+          Please login to jenkins job <pre>`z-clean-resources-azure`</pre> to find out why
           it is failing.
           <br />
           $DEFAULT_CONTENT

--- a/tests/suites/static_analysis/lint_yaml.sh
+++ b/tests/suites/static_analysis/lint_yaml.sh
@@ -52,7 +52,7 @@ jobs:
     - github-mgo-merge-jobs
     - github-prs
     - sync-ntp
-    - z-clean-azure
+    - z-clean-resources-azure
     - z-clean-resources-aws
     - z-clean-resources-gce
     - z-clean-resources-gke
@@ -62,6 +62,8 @@ jobs:
     - z-clean-resources-rackspace
     - z-clean-resources-vsphere
     - z-clean-resources-windows
+    - z-clean-resources-eks
+    - z-clean-resources-ecr
     - run-unit-tests-lxd
 
     # TODO (stickupkid): The followng jobs seem to be orphan jobs with in the
@@ -80,13 +82,11 @@ jobs:
     - public-clouds
     - lxd-src-command-focal-base
     - test-manual-multijob
-    - z-clean-resources-eks
     - github-juju-experimental-check-jobs
     - juju-integration-deploy
     - nw-deploy-focal-amd64-lxd
     - get-s3-build-payload-exotic
     - integration-test-runner-focal
-    - z-clean-resources-ecr
 EOF
 )
   if [ -n "${OUT}" ]; then

--- a/tools/gen-wire-tests/main.go
+++ b/tools/gen-wire-tests/main.go
@@ -400,7 +400,7 @@ const Template = `
     {{- end }}
 
     {{- $builder := "run-integration-test" -}}
-    {{- $run_on := "integration-tests" -}}
+    {{- $run_on := "ephemeral-focal-small-amd64" -}}
     {{- if or (eq (index $node.Ephemeral $test_name) true) (eq $provider_name "lxd") }}
       {{- $builder = "run-integration-test-ephemeral" -}}
       {{- $run_on = "ephemeral-focal-8c-32g-amd64" -}}


### PR DESCRIPTION
The node label `integration-tests` no longer exists, use `ephemeral-focal-small-amd64` instead.