### PR TITLE
Add Python3.10 test case for python-libjuju CI

### DIFF
--- a/jobs/github/python-libjuju.yaml
+++ b/jobs/github/python-libjuju.yaml
@@ -4,6 +4,9 @@
       - edge:
           PYTHON_VERSION: "3"
           JUJU_CHANNEL: "2.9/edge"
+      - python3.10:
+          PYTHON_VERSION: "3.10"
+          JUJU_CHANNEL: "stable"
       - python3.9:
           PYTHON_VERSION: "3.9"
           JUJU_CHANNEL: "stable"

--- a/jobs/github/scripts/pylibjuju-schema-test.sh
+++ b/jobs/github/scripts/pylibjuju-schema-test.sh
@@ -9,7 +9,7 @@
 
     sudo add-apt-repository ppa:deadsnakes/ppa
     sudo apt-get update -q
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git gcc make python3.5 python3.6 python3.7 python3.8 python3-pip
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git gcc make python3.5 python3.6 python3.7 python3.8 python3-pip python3.9 python3.10
 
     # now go to libjuju and make sure it's working correctly
     mkdir -p ~/tmp

--- a/jobs/github/scripts/snippet_build_check-juju-python-libjuju.sh
+++ b/jobs/github/scripts/snippet_build_check-juju-python-libjuju.sh
@@ -7,7 +7,7 @@
 
   sudo add-apt-repository ppa:deadsnakes/ppa
   sudo apt-get update -q
-  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git gcc make python3.5 python3.6 python3.7 python3.8 python3.9 python3-pip python3.5-dev python3.6-dev python3.7-dev python3.8-dev python3.9-dev python3.9-distutils
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git gcc make python3.5 python3.6 python3.7 python3.8 python3.9 python3-pip python3.5-dev python3.6-dev python3.7-dev python3.8-dev python3.9-dev python3.9-distutils python3.10 python3.10-dev python3.10-distutils
 
   set +e  # Will fail in reports gen if any errors occur
   set -o pipefail  # Need to error for make, not tees' success.


### PR DESCRIPTION
This spawns new test jobs for python-libjuju CI tests using `python 3.10`.