### PR TITLE
Add commented out unit tests into the lint ignore so static_analysis

### DIFF
--- a/tests/suites/static_analysis/lint_yaml.sh
+++ b/tests/suites/static_analysis/lint_yaml.sh
@@ -51,7 +51,18 @@ jobs:
     - github-mgo-check-jobs
     - github-mgo-merge-jobs
     - github-prs
+    - nw-deploy-xenial-ppc64el-lxd
+    - nw-deploy-xenial-s390x-lxd
+    - prepare-ephemeral-functional-test-exotic
+    - prepare-functional-test
     - sync-ntp
+    - unit-tests-arm64
+    - unit-tests-arm64-bionic
+    - unit-tests-centos9
+    - unit-tests-ppc64el-bionic
+    - unit-tests-race-arm64
+    - unit-tests-s390x-bionic
+    - unit-tests-win2012
     - z-clean-resources-azure
     - z-clean-resources-aws
     - z-clean-resources-gce


### PR DESCRIPTION
There are a list of unit test jobs commented out temporarily because of the current jenkins setup. These need to be included in the "ignore list" within the `lint_yaml.sh` so the static analysis runs ok.