### PR TITLE
Move some passing tests to gating

### DIFF
--- a/jobs/ci-run/functional/gating-functional-tests.yml
+++ b/jobs/ci-run/functional/gating-functional-tests.yml
@@ -37,6 +37,9 @@
               current-parameters: true
             - name: nw-deploy-bionic-aks
               current-parameters: true
+            - name: nw-deploy-bionic-microk8s
+              disabled: true # nameserver fix required on microk8s
+              current-parameters: true
             - name: nw-charm-storage
               current-parameters: true
             - name: nw-clouds-display

--- a/jobs/ci-run/functional/proving-grounds-functional-tests.yml
+++ b/jobs/ci-run/functional/proving-grounds-functional-tests.yml
@@ -45,9 +45,6 @@
               current-parameters: true
             - name: nw-deploy-client-macos
               current-parameters: true
-            - name: nw-deploy-bionic-microk8s
-              disabled: true # nameserver fix required on microk8s
-              current-parameters: true
             - name: nw-model-migration-amd64-azure-arm
               current-parameters: true
             - name: nw-model-migration-versions-lxd

--- a/jobs/ci-run/integration/integrationtests.yml
+++ b/jobs/ci-run/integration/integrationtests.yml
@@ -70,11 +70,19 @@
       - multijob:
           name: 'gating-integration-tests-amd64'
           projects:
+            - name: 'test-agents-multijob'
+              current-parameters: true
+              predefined-parameters: |-
+                BUILD_ARCH=amd64
             - name: 'test-appdata-multijob'
               current-parameters: true
               predefined-parameters: |-
                 BUILD_ARCH=amd64
             - name: 'test-backup-multijob'
+              current-parameters: true
+              predefined-parameters: |-
+                BUILD_ARCH=amd64
+            - name: 'test-bootstrap-multijob'
               current-parameters: true
               predefined-parameters: |-
                 BUILD_ARCH=amd64
@@ -119,6 +127,10 @@
               predefined-parameters: |-
                 BUILD_ARCH=amd64
             - name: 'test-machine-multijob'
+              current-parameters: true
+              predefined-parameters: |-
+                BUILD_ARCH=amd64
+            - name: 'test-network-multijob'
               current-parameters: true
               predefined-parameters: |-
                 BUILD_ARCH=amd64
@@ -176,24 +188,11 @@
       - multijob:
           name: proving-grounds-integration-tests-amd64
           projects:
-            - name: 'test-agents-multijob'
-              current-parameters: true
-              predefined-parameters: |-
-                BUILD_ARCH=amd64
-            - name: 'test-bootstrap-multijob'
-              current-parameters: true
-              enable-condition: '!["2.8"].contains("${JUJU_VERSION_MAJOR_MINOR}")'
-              predefined-parameters: |-
-                BUILD_ARCH=amd64
             - name: 'test-deploy-unstable-multijob'
               current-parameters: true
               predefined-parameters: |-
                 BUILD_ARCH=amd64
             - name: 'test-model-multijob'
-              current-parameters: true
-              predefined-parameters: |-
-                BUILD_ARCH=amd64
-            - name: 'test-network-multijob'
               current-parameters: true
               predefined-parameters: |-
                 BUILD_ARCH=amd64


### PR DESCRIPTION
Some proving grounds tests have been passing regularly, so move to gating.