### PR TITLE
Make mgo install a little more informative

### DIFF
--- a/jobs/github/scripts/snippet_build_basic-make-check.sh
+++ b/jobs/github/scripts/snippet_build_basic-make-check.sh
@@ -2,11 +2,13 @@
 
     NEEDS_MGO=$(echo "${NEEDS_MGO}" | tr '[:upper:]' '[:lower:]')
     if [ "${NEEDS_MGO}" = "true" ]; then
+      echo "Cleaning any existing juju-db snap"
+      sudo snap remove juju-db --purge
       echo "Installing juju-db snap."
       # when running inside a privileged container, snapd fails because udevd isn't
       # running, but on the second occurance it is.
       # see: https://github.com/lxc/lxd/issues/4308
-      sudo snap refresh juju-db --channel=4.4 2> /dev/null || sudo snap install juju-db --channel=4.4 && echo "Installed:" && which juju-db.mongo && juju-db.mongo --version
+      sudo snap install juju-db --channel=4.4 && echo "Installed:" && which juju-db.mongo && juju-db.mongo --version
     fi
     if [ ! -z "${EXTRA_PACKAGES}" ]; then
       echo "Installing packages ${EXTRA_PACKAGES}"

--- a/jobs/github/scripts/snippet_build_basic-make-check.sh
+++ b/jobs/github/scripts/snippet_build_basic-make-check.sh
@@ -11,7 +11,7 @@
       # running, but on the second occurance it is.
       # see: https://github.com/lxc/lxd/issues/4308
       for i in {1..3}; do
-        echo $action"ing juju-db snap. Attempt ""$i"
+        echo "${action}ing juju-db snap. Attempt ${i}"
         sudo snap $action juju-db --channel=4.4 && echo $action"ed:" && which juju-db.mongo && juju-db.mongo --version && break || sleep 10
       done
     fi

--- a/jobs/github/scripts/snippet_build_basic-make-check.sh
+++ b/jobs/github/scripts/snippet_build_basic-make-check.sh
@@ -12,7 +12,12 @@
       # see: https://github.com/lxc/lxd/issues/4308
       for i in {1..3}; do
         echo "${action}ing juju-db snap. Attempt ${i}"
-        sudo snap $action juju-db --channel=4.4 && echo $action"ed:" && which juju-db.mongo && juju-db.mongo --version && break || sleep 10
+        if sudo snap $action juju-db --channel=4.4; then
+          echo $action"ed:"
+          # If juju-db is correctly installed, report the version and stop looping
+          which juju-db.mongod && juju-db.mongod --version && break
+       fi
+        sleep 10
       done
     fi
     if [ ! -z "${EXTRA_PACKAGES}" ]; then

--- a/jobs/github/scripts/snippet_build_basic-make-check.sh
+++ b/jobs/github/scripts/snippet_build_basic-make-check.sh
@@ -12,7 +12,7 @@
       # see: https://github.com/lxc/lxd/issues/4308
       for i in {1..3}; do
         echo $action"ing juju-db snap. Attempt ""$i"
-        sudo snap install juju-db --channel=4.4 && echo "Installed:" && which juju-db.mongo && juju-db.mongo --version && break || sleep 10
+        sudo snap $action juju-db --channel=4.4 && echo $action"ed:" && which juju-db.mongo && juju-db.mongo --version && break || sleep 10
       done
     fi
     if [ ! -z "${EXTRA_PACKAGES}" ]; then

--- a/jobs/github/scripts/snippet_build_basic-make-check.sh
+++ b/jobs/github/scripts/snippet_build_basic-make-check.sh
@@ -6,7 +6,7 @@
       # when running inside a privileged container, snapd fails because udevd isn't
       # running, but on the second occurance it is.
       # see: https://github.com/lxc/lxd/issues/4308
-      sudo snap refresh juju-db --channel=4.4 2> /dev/null || sudo snap install juju-db --channel=4.4
+      sudo snap refresh juju-db --channel=4.4 2> /dev/null || sudo snap install juju-db --channel=4.4 && echo "Installed:" && which juju-db.mongo && juju-db.mongo --version
     fi
     if [ ! -z "${EXTRA_PACKAGES}" ]; then
       echo "Installing packages ${EXTRA_PACKAGES}"


### PR DESCRIPTION
For jobs that `NEEDS_MGO`, we'll see an output like the following after installing `juju-db`:

```
Installed: 
/snap/bin/juju-db.mongo
MongoDB shell version v4.4.11
Build Info: {
    "version": "4.4.11",
    "gitVersion": "b7530cacde8432d2f22ed506f258ff9c3b45c5e9",
    "openSSLVersion": "OpenSSL 1.1.1f  31 Mar 2020",
    "modules": [],
    "allocator": "tcmalloc",
    "environment": {
        "distarch": "x86_64",
        "target_arch": "x86_64"
    }
}
```

