### PR TITLE
[JUJU-1190] Drop nw-block-commands from functional tests

### DIFF
--- a/jobs/ci-run/functional/gating-functional-tests.yml
+++ b/jobs/ci-run/functional/gating-functional-tests.yml
@@ -31,8 +31,6 @@
             # Please keep it that way!
             - name: nw-assess-persistent-storage
               current-parameters: true
-            - name: nw-block-commands
-              current-parameters: true
             - name: nw-deploy-bionic-gke
               current-parameters: true
             - name: nw-deploy-bionic-aks


### PR DESCRIPTION
This was forgotten in the previous PR