### PR TITLE
[JUJU-1172] More cpu and memory on the ephemeral node for pylibjuju tests

### DIFF
--- a/jobs/github/python-libjuju.yaml
+++ b/jobs/github/python-libjuju.yaml
@@ -29,7 +29,7 @@
     name: github-integration-tests-pylibjuju-{project_name}
     description: |-
       Run python libjuju integration tests
-    node: ephemeral-github-medium-amd64
+    node: ephemeral-github-8c-32g-amd64
     concurrent: false
     parameters:
     - string:


### PR DESCRIPTION
Python-libjuju integration tests take more than 2 hours on the `ephemeral-github-medium-amd64` (t3a.medium), so it fails with a
timeout, so we're moving to `ephemeral-github-8c-32g-amd64` (m5a.2xlarge) 

Side note; technically m5a.xlarge also works -doesn't timeout- but it takes too long (to wait for tests on a PR every time). The ideal is m5a.4xlarge, which I believe what was being used before the latest changes, but m5a.2xlarge is fine too (half the price :moneybag:)