### PR TITLE
Fixed python landing jobs and goversion check

### DIFF
--- a/jobs/github/github-check-merge.yml
+++ b/jobs/github/github-check-merge.yml
@@ -142,7 +142,11 @@
       - set-common-environment
       - detect-merge-go-version
       - install-common-tools
-      - setup-go-environment
+      - conditional-step:
+          condition-kind: shell
+          condition-command: "[[ -v ${{GOVERSION}} ]]"
+          steps:
+            - setup-go-environment
       - shell: |-
           #!/bin/bash
           set -eu
@@ -238,7 +242,11 @@
       - set-common-environment
       - detect-merge-go-version
       - install-common-tools
-      - setup-go-environment
+      - conditional-step:
+          condition-kind: shell
+          condition-command: "[[ -v ${{GOVERSION}} ]]"
+          steps:
+            - setup-go-environment
       - shell: |-
           # Workaround not being able to black list branches as a job argument
           # (cannot pass a list of strings as a job-template param).

--- a/jobs/github/scripts/goversion.sh
+++ b/jobs/github/scripts/goversion.sh
@@ -46,7 +46,14 @@ fi
 
 merge_commit=$(jq -r ".\"merge_commit_sha\"" "$tmpname")
 
-gomod=$(curl -s "https://raw.githubusercontent.com/$ghprbGhRepository/$merge_commit/go.mod")
+set +e
+gomod=$(curl -fs "https://raw.githubusercontent.com/$ghprbGhRepository/$merge_commit/go.mod")
+rval=$?
+if [ $rval -ne 0 ]; then
+  touch "${WORKSPACE}/goversion"
+  exit 0
+fi
+set -e
 goversion=$(echo "$gomod" | grep "go 1." | sed 's/^go 1\.\(.*\)$/1.\1/')
 
 if [[ "$goversion" < "1.14" ]]; then


### PR DESCRIPTION
Makes goversion checking optional for repo's that don't have a go.mod file