### PR TITLE
[JUJU-1172] Install the latest pip for python3.10

### DIFF
--- a/jobs/github/scripts/pylibjuju-integration-test.sh
+++ b/jobs/github/scripts/pylibjuju-integration-test.sh
@@ -23,6 +23,10 @@ sudo apt-get remove -qy --purge lxd lxd-client
 sudo snap remove lxd
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git make "python${PYTHON_VERSION}" "python${MAINLINE_PYTHON_VERSION}-distutils" "python3-pip"
 
+if [ "${PY_VERSION}" = "py310" ]; then
+  curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
+fi
+
 PYTHON_PATH=$(which "python${PYTHON_VERSION}")
 $PYTHON_PATH -m pip install --user tox
 


### PR DESCRIPTION
Current pip from python3-pip cannot load some external libs such as `html5lib`, so we're getting errors like:

`ImportError: cannot import name 'html5lib' from 'pip._vendor' (/usr/lib/python3/dist-packages/pip/_vendor/__init__.py)`

This change gets the latest pip so the py310 tests run just fine. For reference, see https://github.com/juju/python-libjuju/pull/681