### PR TITLE
Use jammy for OCI based jobs (microk8s/docker) to mitigate bug

### DIFF
--- a/jobs/ci-run/integration/aws/test-ck.yml
+++ b/jobs/ci-run/integration/aws/test-ck.yml
@@ -1,6 +1,6 @@
 - job:
     name: test-ck-aws
-    node: ephemeral-focal-8c-32g-amd64
+    node: ephemeral-jammy-8c-32g-amd64
     description: |-
       Test ck suite on aws
     condition: SUCCESSFUL

--- a/jobs/ci-run/integration/gen/test-caasadmission.yml
+++ b/jobs/ci-run/integration/gen/test-caasadmission.yml
@@ -45,7 +45,7 @@
 
 - job:
     name: test-caasadmission-test-controller-model-admission-microk8s
-    node: ephemeral-focal-8c-32g-amd64
+    node: ephemeral-jammy-8c-32g-amd64
     description: |-
       Test test_controller_model_admission in caasadmission suite on microk8s
     parameters:
@@ -93,7 +93,7 @@
 
 - job:
     name: test-caasadmission-test-model-chicken-and-egg-microk8s
-    node: ephemeral-focal-8c-32g-amd64
+    node: ephemeral-jammy-8c-32g-amd64
     description: |-
       Test test_model_chicken_and_egg in caasadmission suite on microk8s
     parameters:
@@ -141,7 +141,7 @@
 
 - job:
     name: test-caasadmission-test-new-model-admission-microk8s
-    node: ephemeral-focal-8c-32g-amd64
+    node: ephemeral-jammy-8c-32g-amd64
     description: |-
       Test test_new_model_admission in caasadmission suite on microk8s
     parameters:

--- a/jobs/ci-run/integration/gen/test-sidecar.yml
+++ b/jobs/ci-run/integration/gen/test-sidecar.yml
@@ -43,7 +43,7 @@
 
 - job:
     name: test-sidecar-test-deploy-and-force-remove-application-microk8s
-    node: ephemeral-focal-8c-32g-amd64
+    node: ephemeral-jammy-8c-32g-amd64
     description: |-
       Test test_deploy_and_force_remove_application in sidecar suite on microk8s
     parameters:
@@ -91,7 +91,7 @@
 
 - job:
     name: test-sidecar-test-deploy-and-remove-application-microk8s
-    node: ephemeral-focal-8c-32g-amd64
+    node: ephemeral-jammy-8c-32g-amd64
     description: |-
       Test test_deploy_and_remove_application in sidecar suite on microk8s
     parameters:


### PR DESCRIPTION
On focal there appears to be a bug with containerd or the kernel we currently have that is causing all the pipes on the system to close. Use jammy instead, until we have time to look into the issue.