### PR TITLE
[JUJU-1320] Replace ProviderName with Cloud struct in gen-wire templating

### DIFF
--- a/jobs/ci-run/integration/gen/test-agents.yml
+++ b/jobs/ci-run/integration/gen/test-agents.yml
@@ -117,6 +117,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES

--- a/jobs/ci-run/integration/gen/test-agents.yml
+++ b/jobs/ci-run/integration/gen/test-agents.yml
@@ -62,7 +62,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:

--- a/jobs/ci-run/integration/gen/test-appdata.yml
+++ b/jobs/ci-run/integration/gen/test-appdata.yml
@@ -117,6 +117,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES

--- a/jobs/ci-run/integration/gen/test-appdata.yml
+++ b/jobs/ci-run/integration/gen/test-appdata.yml
@@ -62,7 +62,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:

--- a/jobs/ci-run/integration/gen/test-backup.yml
+++ b/jobs/ci-run/integration/gen/test-backup.yml
@@ -117,6 +117,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES

--- a/jobs/ci-run/integration/gen/test-backup.yml
+++ b/jobs/ci-run/integration/gen/test-backup.yml
@@ -62,7 +62,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:

--- a/jobs/ci-run/integration/gen/test-bootstrap.yml
+++ b/jobs/ci-run/integration/gen/test-bootstrap.yml
@@ -60,7 +60,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:

--- a/jobs/ci-run/integration/gen/test-branches.yml
+++ b/jobs/ci-run/integration/gen/test-branches.yml
@@ -66,7 +66,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -162,7 +162,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:

--- a/jobs/ci-run/integration/gen/test-branches.yml
+++ b/jobs/ci-run/integration/gen/test-branches.yml
@@ -122,6 +122,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
@@ -217,6 +221,10 @@
         default: 'aws'
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-charmhub.yml
+++ b/jobs/ci-run/integration/gen/test-charmhub.yml
@@ -70,7 +70,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -166,7 +166,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -262,7 +262,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:

--- a/jobs/ci-run/integration/gen/test-charmhub.yml
+++ b/jobs/ci-run/integration/gen/test-charmhub.yml
@@ -126,6 +126,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
@@ -222,6 +226,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
@@ -317,6 +325,10 @@
         default: 'aws'
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-cli.yml
+++ b/jobs/ci-run/integration/gen/test-cli.yml
@@ -68,7 +68,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -116,7 +116,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -164,7 +164,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -212,7 +212,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -260,7 +260,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:

--- a/jobs/ci-run/integration/gen/test-controller.yml
+++ b/jobs/ci-run/integration/gen/test-controller.yml
@@ -66,7 +66,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -162,7 +162,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:

--- a/jobs/ci-run/integration/gen/test-controller.yml
+++ b/jobs/ci-run/integration/gen/test-controller.yml
@@ -122,6 +122,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
@@ -217,6 +221,10 @@
         default: 'aws'
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-deploy.yml
+++ b/jobs/ci-run/integration/gen/test-deploy.yml
@@ -70,7 +70,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -166,7 +166,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -262,7 +262,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -358,7 +358,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -454,7 +454,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:

--- a/jobs/ci-run/integration/gen/test-deploy.yml
+++ b/jobs/ci-run/integration/gen/test-deploy.yml
@@ -126,6 +126,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
@@ -221,6 +225,10 @@
         default: 'aws'
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
@@ -318,6 +326,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
@@ -414,6 +426,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
@@ -509,6 +525,10 @@
         default: 'aws'
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-hooks.yml
+++ b/jobs/ci-run/integration/gen/test-hooks.yml
@@ -66,7 +66,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -162,7 +162,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:

--- a/jobs/ci-run/integration/gen/test-hooks.yml
+++ b/jobs/ci-run/integration/gen/test-hooks.yml
@@ -122,6 +122,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
@@ -217,6 +221,10 @@
         default: 'aws'
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-hooktools.yml
+++ b/jobs/ci-run/integration/gen/test-hooktools.yml
@@ -117,6 +117,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES

--- a/jobs/ci-run/integration/gen/test-hooktools.yml
+++ b/jobs/ci-run/integration/gen/test-hooktools.yml
@@ -62,7 +62,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:

--- a/jobs/ci-run/integration/gen/test-machine.yml
+++ b/jobs/ci-run/integration/gen/test-machine.yml
@@ -117,6 +117,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES

--- a/jobs/ci-run/integration/gen/test-machine.yml
+++ b/jobs/ci-run/integration/gen/test-machine.yml
@@ -62,7 +62,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:

--- a/jobs/ci-run/integration/gen/test-manual.yml
+++ b/jobs/ci-run/integration/gen/test-manual.yml
@@ -66,7 +66,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -162,7 +162,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:

--- a/jobs/ci-run/integration/gen/test-manual.yml
+++ b/jobs/ci-run/integration/gen/test-manual.yml
@@ -122,6 +122,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
@@ -217,6 +221,10 @@
         default: 'aws'
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-model.yml
+++ b/jobs/ci-run/integration/gen/test-model.yml
@@ -74,7 +74,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -170,7 +170,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -266,7 +266,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -362,7 +362,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:

--- a/jobs/ci-run/integration/gen/test-model.yml
+++ b/jobs/ci-run/integration/gen/test-model.yml
@@ -130,6 +130,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
@@ -225,6 +229,10 @@
         default: 'aws'
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
@@ -322,6 +330,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
@@ -417,6 +429,10 @@
         default: 'aws'
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-network.yml
+++ b/jobs/ci-run/integration/gen/test-network.yml
@@ -117,6 +117,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES

--- a/jobs/ci-run/integration/gen/test-network.yml
+++ b/jobs/ci-run/integration/gen/test-network.yml
@@ -62,7 +62,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:

--- a/jobs/ci-run/integration/gen/test-relations.yml
+++ b/jobs/ci-run/integration/gen/test-relations.yml
@@ -70,7 +70,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -166,7 +166,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -262,7 +262,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:

--- a/jobs/ci-run/integration/gen/test-relations.yml
+++ b/jobs/ci-run/integration/gen/test-relations.yml
@@ -126,6 +126,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
@@ -222,6 +226,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
@@ -317,6 +325,10 @@
         default: 'aws'
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-resources.yml
+++ b/jobs/ci-run/integration/gen/test-resources.yml
@@ -66,7 +66,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -162,7 +162,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:

--- a/jobs/ci-run/integration/gen/test-resources.yml
+++ b/jobs/ci-run/integration/gen/test-resources.yml
@@ -122,6 +122,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
@@ -217,6 +221,10 @@
         default: 'aws'
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-smoke.yml
+++ b/jobs/ci-run/integration/gen/test-smoke.yml
@@ -66,7 +66,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
@@ -162,7 +162,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:

--- a/jobs/ci-run/integration/gen/test-smoke.yml
+++ b/jobs/ci-run/integration/gen/test-smoke.yml
@@ -122,6 +122,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
@@ -217,6 +221,10 @@
         default: 'aws'
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-unit.yml
+++ b/jobs/ci-run/integration/gen/test-unit.yml
@@ -117,6 +117,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES

--- a/jobs/ci-run/integration/gen/test-unit.yml
+++ b/jobs/ci-run/integration/gen/test-unit.yml
@@ -62,7 +62,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:

--- a/jobs/ci-run/integration/gen/test-upgrade.yml
+++ b/jobs/ci-run/integration/gen/test-upgrade.yml
@@ -60,7 +60,7 @@
         - s390x
         - ppc64el
     - string:
-        default: 'localhost'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:

--- a/tools/gen-wire-tests/main.go
+++ b/tools/gen-wire-tests/main.go
@@ -42,7 +42,16 @@ type Task struct {
 type Cloud struct {
 	CloudName    string
 	ProviderName string
+	Region       string
 }
+
+var (
+	lxd      = Cloud{CloudName: "lxd", ProviderName: "lxd"}
+	aws      = Cloud{CloudName: "aws", ProviderName: "aws", Region: "us-east-1"}
+	google   = Cloud{CloudName: "google", ProviderName: "google", Region: "us-east1"}
+	azure    = Cloud{CloudName: "azure", ProviderName: "azure", Region: "centralus"}
+	microk8s = Cloud{CloudName: "microk8s", ProviderName: "k8s"}
+)
 
 // Gen-wire-tests will generate the integration test files for the juju
 // integration tests. This will help prevent wire up mistakes or any missing
@@ -124,19 +133,19 @@ func main() {
 
 		clouds := make([]Cloud, 0)
 		if !contains(config.Folders.SkipLXD, suiteName) {
-			clouds = append(clouds, Cloud{CloudName: "lxd", ProviderName: "lxd"})
+			clouds = append(clouds, lxd)
 		}
 		if !contains(config.Folders.SkipAWS, suiteName) {
-			clouds = append(clouds, Cloud{CloudName: "aws", ProviderName: "aws"})
+			clouds = append(clouds, aws)
 		}
 		if !contains(config.Folders.SkipGoogle, suiteName) {
-			clouds = append(clouds, Cloud{CloudName: "google", ProviderName: "google"})
+			clouds = append(clouds, google)
 		}
 		if !contains(config.Folders.SkipAzure, suiteName) {
-			clouds = append(clouds, Cloud{CloudName: "azure", ProviderName: "azure"})
+			clouds = append(clouds, azure)
 		}
 		if !contains(config.Folders.SkipMicrok8s, suiteName) {
-			clouds = append(clouds, Cloud{CloudName: "microk8s", ProviderName: "k8s"})
+			clouds = append(clouds, microk8s)
 		}
 
 		testSuites[suiteName] = Task{
@@ -449,6 +458,12 @@ const Template = `
         default: '{{$cloud.ProviderName}}'
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
+{{- if $cloud.Region }}
+    - string:
+        default: '{{$cloud.Region}}'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+{{- end }}
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/tools/gen-wire-tests/main.go
+++ b/tools/gen-wire-tests/main.go
@@ -33,10 +33,15 @@ type Config struct {
 }
 
 type Task struct {
-	ProviderTypes            []string
+	Clouds                   []Cloud
 	SubTasks                 []string
 	UnstableProviderSubTasks map[string][]string
 	ExcludedTasks            []string
+}
+
+type Cloud struct {
+	CloudName    string
+	ProviderName string
 }
 
 // Gen-wire-tests will generate the integration test files for the juju
@@ -117,25 +122,25 @@ func main() {
 
 		suiteNames = append(suiteNames, suiteName)
 
-		providerTypes := make([]string, 0)
+		clouds := make([]Cloud, 0)
 		if !contains(config.Folders.SkipLXD, suiteName) {
-			providerTypes = append(providerTypes, "lxd")
+			clouds = append(clouds, Cloud{CloudName: "lxd", ProviderName: "lxd"})
 		}
 		if !contains(config.Folders.SkipAWS, suiteName) {
-			providerTypes = append(providerTypes, "aws")
+			clouds = append(clouds, Cloud{CloudName: "aws", ProviderName: "aws"})
 		}
 		if !contains(config.Folders.SkipGoogle, suiteName) {
-			providerTypes = append(providerTypes, "google")
+			clouds = append(clouds, Cloud{CloudName: "google", ProviderName: "google"})
 		}
 		if !contains(config.Folders.SkipAzure, suiteName) {
-			providerTypes = append(providerTypes, "azure")
+			clouds = append(clouds, Cloud{CloudName: "azure", ProviderName: "azure"})
 		}
 		if !contains(config.Folders.SkipMicrok8s, suiteName) {
-			providerTypes = append(providerTypes, "microk8s")
+			clouds = append(clouds, Cloud{CloudName: "microk8s", ProviderName: "k8s"})
 		}
 
 		testSuites[suiteName] = Task{
-			ProviderTypes:            providerTypes,
+			Clouds:                   clouds,
 			SubTasks:                 taskNames,
 			UnstableProviderSubTasks: config.Folders.Unstable[suiteName],
 			ExcludedTasks:            excluded,
@@ -209,7 +214,7 @@ func writeJobDefinitions(
 
 	if err := t.Execute(f, struct {
 		SuiteName     string
-		Providers     []string
+		Clouds        []Cloud
 		TaskNames     []string
 		SkipTasks     []string
 		ExcludedTasks string
@@ -218,7 +223,7 @@ func writeJobDefinitions(
 		Ephemeral     map[string]bool
 	}{
 		SuiteName:     suiteName,
-		Providers:     testSuites[suiteName].ProviderTypes,
+		Clouds:        testSuites[suiteName].Clouds,
 		TaskNames:     testSuites[suiteName].SubTasks,
 		SkipTasks:     joined,
 		ExcludedTasks: strings.Join(testSuites[suiteName].ExcludedTasks, ","),
@@ -374,15 +379,15 @@ const Template = `
         name: 'IntegrationTests-{{.SuiteName}}'
         projects:
 {{- range $k, $skip_tasks := $node.SkipTasks}}
-{{- range $provider_name := $node.Providers}}
-    {{- $unstableTasks := index $node.UnstableTasks $provider_name -}}
+{{- range $cloud := $node.Clouds}}
+    {{- $unstableTasks := index $node.UnstableTasks $cloud.ProviderName -}}
     {{- $task_name := index $node.TaskNames $k -}}
     {{- if eq (len $node.SkipTasks) 1}}
-        - name: 'test-{{$.SuiteName}}-{{$provider_name}}'
+        - name: 'test-{{$.SuiteName}}-{{$cloud.CloudName}}'
           current-parameters: true
     {{- else}}
       {{- if eq (contains $unstableTasks $task_name) $node.Unstable}}
-        - name: 'test-{{$.SuiteName}}-{{ensureHyphen $task_name}}-{{$provider_name}}'
+        - name: 'test-{{$.SuiteName}}-{{ensureHyphen $task_name}}-{{$cloud.CloudName}}'
           current-parameters: true
       {{- end -}}
     {{- end -}}
@@ -390,22 +395,22 @@ const Template = `
 {{- end}}
 
 {{- range $k, $skip_tasks := $node.SkipTasks -}}
-{{- range $provider_name := $node.Providers -}}
+{{- range $cloud := $node.Clouds -}}
     {{- $task_name := "" -}}
-    {{- $test_name := (printf "%s-%s" $.SuiteName $provider_name) -}}
+    {{- $test_name := (printf "%s-%s" $.SuiteName $cloud.CloudName) -}}
     {{- $full_task_name := (printf "test-%s" $test_name) -}}
     {{- if gt (len $node.SkipTasks) 1 }}
         {{- $task_name = index $node.TaskNames $k -}}
-        {{- $full_task_name = (printf "test-%s-%s-%s" $.SuiteName (ensureHyphen $task_name) $provider_name) -}}
+        {{- $full_task_name = (printf "test-%s-%s-%s" $.SuiteName (ensureHyphen $task_name) $cloud.CloudName) -}}
     {{- end }}
 
     {{- $builder := "run-integration-test" -}}
     {{- $run_on := "ephemeral-focal-small-amd64" -}}
-    {{- if or (eq (index $node.Ephemeral $test_name) true) (eq $provider_name "lxd") }}
+    {{- if or (eq (index $node.Ephemeral $test_name) true) (eq $cloud.ProviderName "lxd") }}
       {{- $builder = "run-integration-test" -}}
       {{- $run_on = "ephemeral-focal-8c-32g-amd64" -}}
     {{- end }}
-    {{- if eq $provider_name "microk8s" }}
+    {{- if eq $cloud.CloudName "microk8s" }}
       {{- $builder = "run-integration-test-microk8s" -}}
       {{- $run_on = "ephemeral-focal-8c-32g-amd64" -}}
     {{- end }}
@@ -417,9 +422,9 @@ const Template = `
     node: {{$run_on}}
     description: |-
     {{- if eq (len $node.SkipTasks) 1 }}
-      Test {{$.SuiteName}} suite on {{$provider_name}}
+      Test {{$.SuiteName}} suite on {{$cloud.CloudName}}
     {{ else }}
-      Test {{$task_name}} in {{$.SuiteName}} suite on {{$provider_name}}
+      Test {{$task_name}} in {{$.SuiteName}} suite on {{$cloud.CloudName}}
     {{ end -}}
     parameters:
     - validating-string:
@@ -437,11 +442,11 @@ const Template = `
         - s390x
         - ppc64el
     - string:
-        default: '{{- if eq $provider_name "lxd" }}localhost{{ else }}{{$provider_name}}{{ end -}}'
+        default: '{{$cloud.CloudName}}'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
-        default: '{{- if eq $provider_name "microk8s" }}k8s{{ else }}{{$provider_name}}{{ end -}}'
+        default: '{{$cloud.ProviderName}}'
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:


### PR DESCRIPTION
This means we can properly proceed adding more clouds, particularly the
private clouds, where the provider name and cloud name will differ. Previously
this difference was handled with a couple of hard coded special cases

To keep changes minimal, rename 'localhost' cloud to 'lxd'. This is due to 
how we inconsistently names lxd and microk8s tests (one named technically
after the provider, the other the cloud)

(This PR is in preparation for another upcoming PR)

## QA Steps

Ensure that 
```
make gen-wire-tests
``` 
only
- Changes the BOOTSTRAP_CLOUD envvar to lxd
- Adds some BOOTSTRAP_REGION envvars to public clouds

To verify this change, run: 
```
BOOTSTRAP_CLOUD=lxd BOOSTRAP_PROVIDER=lxd ./main network
```
Successfully runs (only bootstrapping is important)

Also, to test the new regions envvar
```
BOOTSTRAP_CLOUD=aws BOOSTRAP_PROVIDER=aws BOOTSTRAP_REGION=eu-west-2 ./main network
BOOTSTRAP_CLOUD=google BOOSTRAP_PROVIDER=google BOOTSTRAP_REGION=europe-west2 ./main network
BOOTSTRAP_CLOUD=azure BOOSTRAP_PROVIDER=azure BOOTSTRAP_REGION=uksouth ./main network
```