### PR TITLE
[JUJU-1366] Skip Go Download if no GoVersion was found.

### DIFF
--- a/jobs/common/scripts/install-go.sh
+++ b/jobs/common/scripts/install-go.sh
@@ -24,6 +24,11 @@ case $(uname -m) in
     ;;
 esac
 
+if [[ -z "${GOVERSION}" ]]; then
+  echo "No GoVersion defined. Skip Go installation."
+  exit 0
+fi
+
 GOTAR=$(curl -s https://go.dev/dl/ | grep -oE "go${GOVERSION}(\.[0-9]+)?\.linux-${GOARCH}.tar.gz" | head -n1)
 
 wget -q "https://golang.org/dl/${GOTAR}"

--- a/jobs/github/scripts/goversion.sh
+++ b/jobs/github/scripts/goversion.sh
@@ -50,7 +50,8 @@ set +e
 gomod=$(curl -fs "https://raw.githubusercontent.com/$ghprbGhRepository/$merge_commit/go.mod")
 rval=$?
 if [ $rval -ne 0 ]; then
-  echo "GOVERSION=''" > "${WORKSPACE}/goversion"
+  echo "Set default Go version to 1.18.2. This should only be done for non-go projects."
+  echo "GOVERSION=1.18.2" > "${WORKSPACE}/goversion"
   exit 0
 fi
 set -e

--- a/jobs/github/scripts/goversion.sh
+++ b/jobs/github/scripts/goversion.sh
@@ -50,8 +50,7 @@ set +e
 gomod=$(curl -fs "https://raw.githubusercontent.com/$ghprbGhRepository/$merge_commit/go.mod")
 rval=$?
 if [ $rval -ne 0 ]; then
-  echo "Set default Go version to 1.18.2. This should only be done for non-go projects."
-  echo "GOVERSION=1.18.2" > "${WORKSPACE}/goversion"
+  echo "GOVERSION=''" > "${WORKSPACE}/goversion"
   exit 0
 fi
 set -e


### PR DESCRIPTION
Skip the Go download if the GoVersion is unknown. 

---

We expect all projects to have a goversion available and we organize tests accordingly. However, for pythonlib-juju this is not the case and this makes the `github-check-merge-jujju-python-libjuju` test fail. See [this test](https://jenkins.juju.canonical.com/job/github-check-merge-juju-python-libjuju/39/).