### PR TITLE
Fix windows build and disk space issues

### DIFF
--- a/jobs/ci-run/build/buildjuju.yml
+++ b/jobs/ci-run/build/buildjuju.yml
@@ -41,8 +41,6 @@
           regex: ^\S*$
           msg: Enter a build label
     builders:
-      - description-setter:
-          description: "${SHORT_GIT_COMMIT} (go ${GOVERSION})"
       - wait-for-cloud-init
       - set-common-environment
       - install-common-tools
@@ -71,21 +69,13 @@
           condition-operands:
             - condition-kind: regex-match
               label: "$PLATFORM"
-              regex: "^(?!darwin).*"
+              regex: "^(?!(darwin|windows)).*"
             - condition-kind: strings-match
               condition-string1: "$LABEL"
               condition-string2: ""
           steps:
             - upload-s3-agent-binaries:
                 platform: ${PLATFORM}
-    publishers:
-      - archive:
-          artifacts: "build/**/bin/juju_binaries*.xz"
-          allow-empty: false
-          only-if-success: false
-          fingerprint: false
-          default-excludes: true
-          case-sensitive: true
 
 - builder:
     name: "make-windows-installer"
@@ -175,8 +165,6 @@
           description: "Space seperated list of Go Platforms to build the OCI images for"
           name: BUILD_PLATFORMS
     builders:
-      - description-setter:
-          description: "${SHORT_GIT_COMMIT} (go ${GOVERSION})"
       - wait-for-cloud-init
       - set-common-environment
       - install-common-tools
@@ -223,18 +211,30 @@
             juju_name=juju.exe
           fi
 
-          jujud_name=jujud
-          if [[ -f "${{build_platform_dir}}/jujud.exe" ]]; then
+          jujud_name=
+          if [[ -f "${{build_platform_dir}}/jujud" ]]; then
+            echo "jujud exists for platform {platform}"
+            jujud_name=jujud
+          elif [[ -f "${{build_platform_dir}}/jujud.exe" ]]; then
+            echo "jujud exists for platform {platform}"
             jujud_name=jujud.exe
           fi
 
-          jujuc_name=jujuc
-          if [[ -f "${{build_platform_dir}}/jujuc.exe" ]]; then
+          jujuc_name=
+          if [[ -f "${{build_platform_dir}}/jujuc" ]]; then
+            echo "jujuc exists for platform {platform}"
+            jujuc_name=jujuc
+          elif [[ -f "${{build_platform_dir}}/jujuc.exe" ]]; then
+            echo "jujuc exists for platform {platform}"
             jujuc_name=jujuc.exe
           fi
 
-          juju_metadata_name=juju-metadata
-          if [[ -f "${{build_platform_dir}}/juju-metadata.exe" ]]; then
+          juju_metadata_name=
+          if [[ -f "${{build_platform_dir}}/juju-metadata" ]]; then
+            echo "juju-metadata exists for platform {platform}"
+            juju_metadata_name=juju-metadata
+          elif [[ -f "${{build_platform_dir}}/juju-metadata.exe" ]]; then
+            echo "juju-metadata exists for platform {platform}"
             juju_metadata_name=juju-metadata.exe
           fi
 
@@ -303,6 +303,11 @@
             ${{juju_installer_name}} \
             ${{wait_for_name}}
 
+          if [[ -z "${{jujud_name}}" && -z "${{jujuc_name}}" ]]; then
+            echo "no agent tarball for platform {platform}" 
+            exit 0
+          fi
+          
           agent_tarball_name=juju-${{JUJU_VERSION}}-${{os}}${{FILE_LABEL}}-${{arch}}.tgz
           echo "Creating agent payload for {platform} - ${{agent_tarball_name}}"
 

--- a/jobs/ci-run/build/streams.yaml
+++ b/jobs/ci-run/build/streams.yaml
@@ -1,6 +1,6 @@
 ## Jobs and builders for handling agent json
 - job:
-    name: "generate-agent-testing-streams"
+    name: generate-agent-testing-streams
     node: ephemeral-focal-8c-32g-amd64
     description: |-
       Build simple streams agent product json
@@ -17,7 +17,7 @@
       - get-build-details
       - get-s3-agent-payload:
           dest: ${WORKSPACE}
-          platforms: linux/amd64 linux/arm64 linux/s390x linux/ppc64el windows/amd64
+          platforms: linux/amd64 linux/arm64 linux/s390x linux/ppc64el
       - shell: |-
           #!/bin/bash
           set -e
@@ -29,10 +29,6 @@
       - generate-agent-json:
           platforms: linux/amd64 linux/arm64 linux/s390x linux/ppc64el
           product_name: centos
-          output_dir: "${WORKSPACE}/agent_json"
-      - generate-agent-json:
-          platforms: windows/amd64
-          product_name: windows
           output_dir: "${WORKSPACE}/agent_json"
       - install-simplestreams
       - install-s3cmd
@@ -58,17 +54,17 @@
 
 - builder:
     # Used to generate agent metadata for CI tests
-    name: "generate-agent-json"
+    name: generate-agent-json
     # Note: This builder expects the following parameters
     #  (they are used within the script)
-    # platforms: space seperated list of go style platforms (e.g. linux/arm64 windows/amd64)
-    # product_name: Product name to use (e.g. windows, ubuntu, centos)
+    # platforms: space seperated list of go style platforms (e.g. linux/arm64 centos/amd64)
+    # product_name: Product name to use (e.g. ubuntu, centos)
     # output_dir: The directory in which to place the resulting json files
     builders:
       - shell: !include-raw: ../scripts/generate-agent-json.sh
 
 - job:
-    name: 'publish-testing-streams-aws'
+    name: publish-testing-streams-aws
     description: |-
       Publish stream metadata and agents from this build for use in
       functional testing.
@@ -96,7 +92,7 @@
           mkdir -p ${WORKSPACE}/agent/build-${JUJU_VERSION}-${SHORT_GIT_COMMIT}/
       - get-s3-agent-payload:
           dest: ${WORKSPACE}/agent/build-${JUJU_VERSION}-${SHORT_GIT_COMMIT}
-          platforms: linux/amd64 linux/arm64 linux/s390x linux/ppc64el windows/amd64
+          platforms: linux/amd64 linux/arm64 linux/s390x linux/ppc64el
       - retrieve-generated-streams
       - install-stream-patcher
       - shell: |-
@@ -127,7 +123,7 @@
 
 
 - job:
-    name: 'publish-testing-streams-azure'
+    name: publish-testing-streams-azure
     description: |-
       Publish stream metadata and agents from this build for use in
       functional testing.
@@ -155,7 +151,7 @@
           mkdir -p ${WORKSPACE}/agent/build-${JUJU_VERSION}-${SHORT_GIT_COMMIT}/
       - get-s3-agent-payload:
           dest: ${WORKSPACE}/agent/build-${JUJU_VERSION}-${SHORT_GIT_COMMIT}
-          platforms: linux/amd64 linux/arm64 linux/s390x linux/ppc64el windows/amd64
+          platforms: linux/amd64 linux/arm64 linux/s390x linux/ppc64el
       - retrieve-generated-streams
       - install-stream-patcher
       - get-azure-creds
@@ -189,7 +185,7 @@
             --destination-path ci-run-streams/builds/build-${SHORT_GIT_COMMIT}/agent
 
 - builder:
-    name: 'retrieve-generated-streams'
+    name: retrieve-generated-streams
     builders:
     - install-s3cmd
     - get-s3-creds
@@ -202,7 +198,7 @@
         tar xf ${GENERATED_STREAMS_TARBALL}
 
 - builder:
-    name: 'install-stream-patcher'
+    name: install-stream-patcher
     builders:
     - shell: |-
           #!/bin/bash

--- a/jobs/ci-run/ci-run-master.yml
+++ b/jobs/ci-run/ci-run-master.yml
@@ -100,7 +100,8 @@
             PATH=/snap/bin:$PATH
             series=bionic
       - get-build-details
-      - set-build-description
+      - description-setter:
+          description: "${JUJU_VERSION}:${SHORT_GIT_COMMIT} (go ${GOVERSION})"
       - multijob:
           name: "Building Juju Binaries"
           condition: SUCCESSFUL
@@ -320,7 +321,3 @@
           git --no-pager log -1
       - package-juju-source
       - put-s3-source-payload
-    publishers:
-      - archive:
-          artifacts: "juju-*.tar.xz"
-          only-if-success: true


### PR DESCRIPTION
Now that we don't build windows agents, the juju build jobs needs to be updated to account for that.

Also fix build description setting issues.

And do not archive build artefacts - these were eating all the disk space, and are stored on s3 anyway.