### PR TITLE
Direct comparison of GOVERSION with the previously empty string.

### DIFF
--- a/jobs/common/scripts/install-go.sh
+++ b/jobs/common/scripts/install-go.sh
@@ -24,7 +24,7 @@ case $(uname -m) in
     ;;
 esac
 
-if [[ -z "${GOVERSION}" ]]; then
+if [[ "${GOVERSION}" == "\'\'" ]]; then
   echo "No GoVersion defined. Skip Go installation."
   exit 0
 fi


### PR DESCRIPTION
This is a minor fix to skip GO installations. If no go.mod is defined the GOVERSION variable is set to `''`. In the previous solution a direct comparison was done against the empty string. This is a direct comparison with this value.