### PR TITLE
Fix string comparison.

### DIFF
--- a/jobs/common/scripts/install-go.sh
+++ b/jobs/common/scripts/install-go.sh
@@ -24,7 +24,7 @@ case $(uname -m) in
     ;;
 esac
 
-if [[ "${GOVERSION}" == "\'\'" ]]; then
+if [[ "$GOVERSION" == "''" ]]; then
   echo "No GoVersion defined. Skip Go installation."
   exit 0
 fi


### PR DESCRIPTION
This is a fix  #41  that is not working because the comparison with the GOVERSION variable fails. This variable was set to '' (empty string declared using two single quotes) and that makes the comparison fail. This change is already tested in the Jenkins script and it works properly.