### PR TITLE
[JUJU-1416] Reduce timeout to something realistic and move out of multi-project

### DIFF
--- a/jobs/ci-run/integration/gen/test-agents.yml
+++ b/jobs/ci-run/integration/gen/test-agents.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -79,6 +75,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'agents'
@@ -130,6 +130,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'agents'

--- a/jobs/ci-run/integration/gen/test-appdata.yml
+++ b/jobs/ci-run/integration/gen/test-appdata.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -79,6 +75,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'appdata'
@@ -130,6 +130,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'appdata'

--- a/jobs/ci-run/integration/gen/test-backup.yml
+++ b/jobs/ci-run/integration/gen/test-backup.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -79,6 +75,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'backup'
@@ -130,6 +130,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'backup'

--- a/jobs/ci-run/integration/gen/test-bootstrap.yml
+++ b/jobs/ci-run/integration/gen/test-bootstrap.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -77,6 +73,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'bootstrap'

--- a/jobs/ci-run/integration/gen/test-branches.yml
+++ b/jobs/ci-run/integration/gen/test-branches.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -83,6 +79,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'branches'
@@ -135,6 +135,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'branches'
@@ -183,6 +187,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'branches'
@@ -235,6 +243,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'branches'

--- a/jobs/ci-run/integration/gen/test-caasadmission.yml
+++ b/jobs/ci-run/integration/gen/test-caasadmission.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -45,7 +41,7 @@
 
 - job:
     name: test-caasadmission-test-controller-model-admission-microk8s
-    node: ephemeral-jammy-8c-32g-amd64
+    node: ephemeral-focal-8c-32g-amd64
     description: |-
       Test test_controller_model_admission in caasadmission suite on microk8s
     parameters:
@@ -81,6 +77,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test-microk8s:
             test_name: 'caasadmission'
@@ -93,7 +93,7 @@
 
 - job:
     name: test-caasadmission-test-model-chicken-and-egg-microk8s
-    node: ephemeral-jammy-8c-32g-amd64
+    node: ephemeral-focal-8c-32g-amd64
     description: |-
       Test test_model_chicken_and_egg in caasadmission suite on microk8s
     parameters:
@@ -129,6 +129,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test-microk8s:
             test_name: 'caasadmission'
@@ -141,7 +145,7 @@
 
 - job:
     name: test-caasadmission-test-new-model-admission-microk8s
-    node: ephemeral-jammy-8c-32g-amd64
+    node: ephemeral-focal-8c-32g-amd64
     description: |-
       Test test_new_model_admission in caasadmission suite on microk8s
     parameters:
@@ -177,6 +181,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test-microk8s:
             test_name: 'caasadmission'

--- a/jobs/ci-run/integration/gen/test-charmhub.yml
+++ b/jobs/ci-run/integration/gen/test-charmhub.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -87,6 +83,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'charmhub'
@@ -139,6 +139,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'charmhub'
@@ -187,6 +191,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'charmhub'
@@ -239,6 +247,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'charmhub'
@@ -287,6 +299,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'charmhub'
@@ -339,6 +355,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'charmhub'

--- a/jobs/ci-run/integration/gen/test-cli.yml
+++ b/jobs/ci-run/integration/gen/test-cli.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -85,6 +81,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'cli'
@@ -133,6 +133,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'cli'
@@ -181,6 +185,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'cli'
@@ -229,6 +237,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'cli'
@@ -277,6 +289,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'cli'

--- a/jobs/ci-run/integration/gen/test-controller.yml
+++ b/jobs/ci-run/integration/gen/test-controller.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -83,6 +79,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'controller'
@@ -135,6 +135,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'controller'
@@ -183,6 +187,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'controller'
@@ -235,6 +243,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'controller'

--- a/jobs/ci-run/integration/gen/test-deploy-unstable.yml
+++ b/jobs/ci-run/integration/gen/test-deploy-unstable.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''

--- a/jobs/ci-run/integration/gen/test-deploy.yml
+++ b/jobs/ci-run/integration/gen/test-deploy.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -87,6 +83,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'deploy'
@@ -139,6 +139,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'deploy'
@@ -187,6 +191,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'deploy'
@@ -239,6 +247,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'deploy'
@@ -287,6 +299,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'deploy'
@@ -339,6 +355,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'deploy'
@@ -387,6 +407,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'deploy'
@@ -439,6 +463,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'deploy'
@@ -487,6 +515,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'deploy'
@@ -539,6 +571,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'deploy'

--- a/jobs/ci-run/integration/gen/test-hooks.yml
+++ b/jobs/ci-run/integration/gen/test-hooks.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -83,6 +79,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'hooks'
@@ -135,6 +135,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'hooks'
@@ -183,6 +187,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'hooks'
@@ -235,6 +243,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'hooks'

--- a/jobs/ci-run/integration/gen/test-hooktools.yml
+++ b/jobs/ci-run/integration/gen/test-hooktools.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -79,6 +75,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'hooktools'
@@ -130,6 +130,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'hooktools'

--- a/jobs/ci-run/integration/gen/test-machine.yml
+++ b/jobs/ci-run/integration/gen/test-machine.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -79,6 +75,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'machine'
@@ -130,6 +130,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'machine'

--- a/jobs/ci-run/integration/gen/test-manual.yml
+++ b/jobs/ci-run/integration/gen/test-manual.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -83,6 +79,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'manual'
@@ -135,6 +135,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'manual'
@@ -183,6 +187,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'manual'
@@ -235,6 +243,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'manual'

--- a/jobs/ci-run/integration/gen/test-model.yml
+++ b/jobs/ci-run/integration/gen/test-model.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -91,6 +87,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'model'
@@ -143,6 +143,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'model'
@@ -191,6 +195,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'model'
@@ -243,6 +251,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'model'
@@ -291,6 +303,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'model'
@@ -343,6 +359,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'model'
@@ -391,6 +411,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'model'
@@ -443,6 +467,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'model'

--- a/jobs/ci-run/integration/gen/test-network.yml
+++ b/jobs/ci-run/integration/gen/test-network.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -83,6 +79,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'network'
@@ -134,6 +134,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'network'
@@ -172,6 +176,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'us-east1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
@@ -181,6 +189,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'network'
@@ -219,6 +231,10 @@
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
     - string:
+        default: 'centralus'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
@@ -228,6 +244,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'network'

--- a/jobs/ci-run/integration/gen/test-relations.yml
+++ b/jobs/ci-run/integration/gen/test-relations.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -87,6 +83,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'relations'
@@ -139,6 +139,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'relations'
@@ -187,6 +191,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'relations'
@@ -239,6 +247,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'relations'
@@ -287,6 +299,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'relations'
@@ -339,6 +355,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'relations'

--- a/jobs/ci-run/integration/gen/test-resources.yml
+++ b/jobs/ci-run/integration/gen/test-resources.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -83,6 +79,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'resources'
@@ -135,6 +135,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'resources'
@@ -183,6 +187,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'resources'
@@ -235,6 +243,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'resources'

--- a/jobs/ci-run/integration/gen/test-sidecar.yml
+++ b/jobs/ci-run/integration/gen/test-sidecar.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -43,7 +39,7 @@
 
 - job:
     name: test-sidecar-test-deploy-and-force-remove-application-microk8s
-    node: ephemeral-jammy-8c-32g-amd64
+    node: ephemeral-focal-8c-32g-amd64
     description: |-
       Test test_deploy_and_force_remove_application in sidecar suite on microk8s
     parameters:
@@ -79,6 +75,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test-microk8s:
             test_name: 'sidecar'
@@ -91,7 +91,7 @@
 
 - job:
     name: test-sidecar-test-deploy-and-remove-application-microk8s
-    node: ephemeral-jammy-8c-32g-amd64
+    node: ephemeral-focal-8c-32g-amd64
     description: |-
       Test test_deploy_and_remove_application in sidecar suite on microk8s
     parameters:
@@ -127,6 +127,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test-microk8s:
             test_name: 'sidecar'

--- a/jobs/ci-run/integration/gen/test-smoke.yml
+++ b/jobs/ci-run/integration/gen/test-smoke.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -83,6 +79,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'smoke'
@@ -135,6 +135,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'smoke'
@@ -183,6 +187,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'smoke'
@@ -235,6 +243,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'smoke'

--- a/jobs/ci-run/integration/gen/test-unit.yml
+++ b/jobs/ci-run/integration/gen/test-unit.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -79,6 +75,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'unit'
@@ -130,6 +130,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'unit'

--- a/jobs/ci-run/integration/gen/test-upgrade.yml
+++ b/jobs/ci-run/integration/gen/test-upgrade.yml
@@ -13,10 +13,6 @@
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -77,6 +73,10 @@
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - run-integration-test:
             test_name: 'upgrade'

--- a/tools/gen-wire-tests/main.go
+++ b/tools/gen-wire-tests/main.go
@@ -364,10 +364,6 @@ const Template = `
     - ansicolor
     - workspace-cleanup
     - timestamps
-    - timeout:
-        timeout: 300
-        fail: true
-        type: absolute
     parameters:
     - string:
         default: ''
@@ -474,6 +470,10 @@ const Template = `
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
     builders:
       - {{$builder}}:
             test_name: '{{$.SuiteName}}'


### PR DESCRIPTION
It turns out the timeout is measures in minutes

Move to individual projects since Multi-project run times are often
inflated waiting for jobs to start

For example, see here:
https://jenkins.juju.canonical.com/job/test-caasadmission-multijob/
As of writing, the most recent multi job took 50 mins, but each of the three jobs only took 15 mins


### QA Steps

Run a job in Jenkins that gets stuck and wait for timeout. For example, 
https://jenkins.juju.canonical.com/job/test-network-aws/126/console