### PR TITLE
Attempt to fix `nw-model-migration-versions-aws`

### DIFF
--- a/jobs/ci-run/functional/amd64/model-migration-versions.yml
+++ b/jobs/ci-run/functional/amd64/model-migration-versions.yml
@@ -24,7 +24,7 @@
           #!/bin/bash
           set -eu
 
-          sudo snap install juju --classic
+          sudo snap install juju --classic --channel=2.9/edge
 
       - functional-python-deps
       - get-cloud-environments


### PR DESCRIPTION
The `nw-model-migration-versions-aws` gating tests are getting an error:
```
ERROR looking up model users in target controller: unknown object type "UserManager" (not implemented)
```

We believe this is because 2.9.32 doesn't allow model migrating to 3.0. Using 2.9.33 (2.9/edge) instead should fix this.