### PR TITLE
[JUJU-1477] Changed timeout for race AMD and ARM tests

### DIFF
--- a/jobs/ci-run/unittest/unittests.yml
+++ b/jobs/ci-run/unittest/unittests.yml
@@ -402,7 +402,7 @@
         description: "Enable sub job to be run individually."
         name: SHORT_GIT_COMMIT
     - string:
-        default: '3000s'
+        default: '5400s'
         name: TEST_TIMEOUT
     - string:
         name: USE_TMPFS_FOR_MGO
@@ -453,7 +453,7 @@
         description: "Enable sub job to be run individually."
         name: SHORT_GIT_COMMIT
     - string:
-        default: '3000s'
+        default: '5400s'
         name: TEST_TIMEOUT
     - string:
         name: USE_TMPFS_FOR_MGO


### PR DESCRIPTION
 Increased the time for race tests for ARM and AMD from 3000s to 5400s