### PR TITLE
Increased timeout for test-deploy-test-deploy-bundles-aws.

### DIFF
--- a/jobs/ci-run/integration/gen/test-deploy.yml
+++ b/jobs/ci-run/integration/gen/test-deploy.yml
@@ -248,7 +248,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 60
           fail: true
           type: absolute
     builders:


### PR DESCRIPTION
Looks like it's not enough time for Jenkins to complete the job: [test-output](https://jenkins.juju.canonical.com/job/test-deploy-test-deploy-bundles-aws/185/console).

This patch increases the timeout from 30 min to 60 min. 

PS: previously, I've tested est-deploy-test-deploy-bundles-aws locally, and all tests passed well on 2.9 . On 3.0 there is still a patch needed (I'll add it sooner).