### PR TITLE
[JUJU-1537] Install latest stable lxd version for pylib integration.

### DIFF
--- a/jobs/github/scripts/pylibjuju-integration-test.sh
+++ b/jobs/github/scripts/pylibjuju-integration-test.sh
@@ -32,7 +32,7 @@ $PYTHON_PATH -m pip install --user tox
 
 attempts=0
 while [ $attempts -lt 3 ]; do
-    sudo snap install lxd --channel=4.24/stable && break || true
+    sudo snap install lxd && break || true
     attempts=$((attempts + 1))
 done
 export PATH="/snap/bin:$PATH"


### PR DESCRIPTION
In one of the executions of the pylib integrations tests we found a message indicating that lxd 4.24/stable package is missing. Install the default lxd snap package available at the moment.

```bash
sudo snap install lxd --channel=4.24/stable
09:51:08 error: snap "lxd" is not available on 4.24/stable but is available to install
09:51:08        on the following channels:
09:51:08 
09:51:08        4.24/candidate  snap install --channel=4.24/candidate lxd
09:51:08        4.24/beta       snap install --channel=4.24/beta lxd
09:51:08        4.24/edge       snap install --channel=4.24/edge lxd
09:51:08 
09:51:08        Please be mindful pre-release channels may include features not
09:51:08        completely tested or implemented. Get more information with 'snap info
09:51:08        lxd'.
```