### PR TITLE
Do not set BOOTSTRAP_SERIES on tests

### DIFF
--- a/jobs/ci-run/ci-run-master.yml
+++ b/jobs/ci-run/ci-run-master.yml
@@ -98,7 +98,7 @@
           properties-content: |-
             OPERATOR_IMAGE_ACCOUNT=jujuqabot
             PATH=/snap/bin:$PATH
-            series=bionic
+            series=focal
       - get-build-details
       - description-setter:
           description: "${JUJU_VERSION}:${SHORT_GIT_COMMIT} (go ${GOVERSION})"
@@ -215,7 +215,6 @@
             current-parameters: true
             predefined-parameters: |-
               series=${series}
-              BOOTSTRAP_SERIES=${series}
               SHORT_GIT_COMMIT=${SHORT_GIT_COMMIT}
               GOVERSION=${GOVERSION}
 
@@ -282,7 +281,6 @@
             current-parameters: true
             predefined-parameters: |-
               series=${series}
-              BOOTSTRAP_SERIES=${series}
               SHORT_GIT_COMMIT=${SHORT_GIT_COMMIT}
               GOVERSION=${GOVERSION}
 


### PR DESCRIPTION
We were setting the test BOOTSTRAP_SERIES to the "series" value used elsewhere for the default test charm series. This is not what's needed and broke tests which need a bootstrap series of focal, since series was set to bionic. We want to allow the tests to use whatever the default series is for bootstrap, unless overridden.

We leave BOOTSTRAP_SERIES empty and also update the default charm series to focal.