### PR TITLE
Changed gating-integration-tests-arm64 job description to limit tests

### DIFF
--- a/jobs/ci-run/integration/aws/test-deploy-arm64.yml
+++ b/jobs/ci-run/integration/aws/test-deploy-arm64.yml
@@ -1,0 +1,33 @@
+- job:
+    name: 'test-deploy-arm64'
+    project-type: 'multijob'
+    description: |-
+      Test deploy Suite
+    condition: SUCCESSFUL
+    node: noop-parent-jobs
+    concurrent: true
+    wrappers:
+      - ansicolor
+      - workspace-cleanup
+      - timestamps
+    parameters:
+      - string:
+          default: ''
+          description: 'Enable sub job to be run individually.'
+          name: SHORT_GIT_COMMIT
+      - string:
+          default: ''
+          description: 'Model arch used to set model arch constraint.'
+          name: MODEL_ARCH
+      - string:
+          default: ''
+          description: 'Ubuntu series to use when bootstrapping Juju'
+          name: BOOTSTRAP_SERIES
+    builders:
+      - get-build-details
+      - set-test-description
+      - multijob:
+          name: 'IntegrationTests-deploy-arm64'
+          projects:
+            - name: 'test-deploy-test-deploy-charms-aws'
+              current-parameters: true

--- a/jobs/ci-run/integration/integrationtests.yml
+++ b/jobs/ci-run/integration/integrationtests.yml
@@ -250,7 +250,7 @@
       - multijob:
           name: 'gating-integration-tests-arm64'
           projects:
-            - name: 'test-deploy-multijob'
+            - name: 'test-deploy-arm64'
               current-parameters: true
               predefined-parameters: |-
                 MODEL_ARCH=arm64

--- a/tests/suites/static_analysis/lint_yaml.sh
+++ b/tests/suites/static_analysis/lint_yaml.sh
@@ -118,6 +118,7 @@ jobs:
     - test-bootstrap-multijob:IntegrationTests-bootstrap
     - test-upgrade-multijob:IntegrationTests-upgrade
     - test-upgrade_series-multijob:IntegrationTests-upgrade_series
+    - test-deploy-arm64:IntegrationTests-deploy-arm64
     - gating-integration-tests-arm64:gating-integration-tests-arm64
 EOF
 )


### PR DESCRIPTION
We wish to use only deploy_charm_aws test (from the deploy suite) in gating-integration-tests-arm64 job.
Here is the patch that does this limitation.