### PR TITLE
Only use a subset of deploy jobs for arm64 gating

### DIFF
--- a/jobs/ci-run/functional/gating-functional-tests.yml
+++ b/jobs/ci-run/functional/gating-functional-tests.yml
@@ -48,13 +48,7 @@
               current-parameters: true
             - name: nw-grant-revoke
               current-parameters: true
-            - name: nw-model-migration-amd64-aws
-              current-parameters: true
             - name: nw-model-migration-versions-aws
-              current-parameters: true
-            - name: nw-model-migration-amd64-lxd
-              current-parameters: true
-            - name: nw-model-migration-amd64-gce
               current-parameters: true
             - name: nw-network-spaces-aws
               current-parameters: true

--- a/jobs/ci-run/functional/proving-grounds-functional-tests.yml
+++ b/jobs/ci-run/functional/proving-grounds-functional-tests.yml
@@ -59,6 +59,10 @@
               current-parameters: true
             - name: nw-upgrade-juju-beta
               current-parameters: true
+            - name: nw-model-migration-amd64-lxd
+              current-parameters: true
+            - name: nw-model-migration-amd64-aws
+              current-parameters: true
             - name: nw-model-migration-amd64-gce
               current-parameters: true
             - name: nw-deploy-kubeflow

--- a/jobs/ci-run/integration/integrationtests.yml
+++ b/jobs/ci-run/integration/integrationtests.yml
@@ -250,7 +250,11 @@
       - multijob:
           name: 'gating-integration-tests-arm64'
           projects:
-            - name: 'test-deploy-multijob'
+            - name: 'test-deploy-test-deploy-bundles-aws'
+              current-parameters: true
+              predefined-parameters: |-
+                MODEL_ARCH=arm64
+            - name: 'test-deploy-test-deploy-charms-aws'
               current-parameters: true
               predefined-parameters: |-
                 MODEL_ARCH=arm64

--- a/tests/suites/static_analysis/lint_yaml.sh
+++ b/tests/suites/static_analysis/lint_yaml.sh
@@ -118,7 +118,6 @@ jobs:
     - test-bootstrap-multijob:IntegrationTests-bootstrap
     - test-upgrade-multijob:IntegrationTests-upgrade
     - test-upgrade_series-multijob:IntegrationTests-upgrade_series
-    - gating-integration-tests-arm64:gating-integration-tests-arm64
 EOF
 )
   if [ -n "${OUT}" ]; then


### PR DESCRIPTION
We only want to use a subset of the deploy tests for arm64 gating right now.

Also, moving failing migration Python tests to proving grounds as they are being replaced by bash tests.