### PR TITLE
[JUJU-1567] Selected arm64 node for arm64 tests.

### DIFF
--- a/jobs/ci-run/integration/integrationtests.yml
+++ b/jobs/ci-run/integration/integrationtests.yml
@@ -250,6 +250,10 @@
       - multijob:
           name: 'gating-integration-tests-arm64'
           projects:
+            - name: 'test-deploy-test-deploy-bundles-aws'
+              current-parameters: true
+              predefined-parameters: |-
+                MODEL_ARCH=arm64
             - name: 'test-deploy-test-deploy-charms-aws'
               current-parameters: true
               predefined-parameters: |-

--- a/jobs/ci-run/integration/integrationtests.yml
+++ b/jobs/ci-run/integration/integrationtests.yml
@@ -227,7 +227,7 @@
     project-type: "multijob"
     description: |-
       intergration-arm64 runs the new shell integration tests with arm64 workloads.
-    node: noop-parent-jobs
+    node: ephemeral-bionic-8c-32g-arm64
     concurrent: true
     wrappers:
       - default-integration-test-wrapper
@@ -250,10 +250,6 @@
       - multijob:
           name: 'gating-integration-tests-arm64'
           projects:
-            - name: 'test-deploy-test-deploy-bundles-aws'
-              current-parameters: true
-              predefined-parameters: |-
-                MODEL_ARCH=arm64
             - name: 'test-deploy-test-deploy-charms-aws'
               current-parameters: true
               predefined-parameters: |-

--- a/tests/suites/static_analysis/lint_yaml.sh
+++ b/tests/suites/static_analysis/lint_yaml.sh
@@ -118,6 +118,7 @@ jobs:
     - test-bootstrap-multijob:IntegrationTests-bootstrap
     - test-upgrade-multijob:IntegrationTests-upgrade
     - test-upgrade_series-multijob:IntegrationTests-upgrade_series
+    - gating-integration-tests-arm64:gating-integration-tests-arm64
 EOF
 )
   if [ -n "${OUT}" ]; then

--- a/tests/suites/static_analysis/lint_yaml.sh
+++ b/tests/suites/static_analysis/lint_yaml.sh
@@ -118,7 +118,6 @@ jobs:
     - test-bootstrap-multijob:IntegrationTests-bootstrap
     - test-upgrade-multijob:IntegrationTests-upgrade
     - test-upgrade_series-multijob:IntegrationTests-upgrade_series
-    - gating-integration-tests-arm64:gating-integration-tests-arm64
 EOF
 )
   if [ -n "${OUT}" ]; then


### PR DESCRIPTION
Firstly, we decided to test hybrid deployments (controller - amd, workloads - arm). But then it's figured out, that amd controller brings only amd agents of the needed version. That means that the juju uniter goes to streams to find the needed version for arm, but, of course, fails because the current version is not in streams yet (it's not released... :) ).

So, hybrid deployment might work after we release some version but will never work in our Jenkins because we always test not release versions.

This patch changes the approach to pure arm deployments and selects the arm Jenkins node for these tests.
