### PR TITLE
[JUJU-1569] Changed timeout from 30 to 50 min in template for tests. 

### DIFF
--- a/jobs/ci-run/integration/gen/test-agents.yml
+++ b/jobs/ci-run/integration/gen/test-agents.yml
@@ -76,7 +76,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -131,7 +131,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-appdata.yml
+++ b/jobs/ci-run/integration/gen/test-appdata.yml
@@ -76,7 +76,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -131,7 +131,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-backup.yml
+++ b/jobs/ci-run/integration/gen/test-backup.yml
@@ -76,7 +76,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -131,7 +131,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-bootstrap.yml
+++ b/jobs/ci-run/integration/gen/test-bootstrap.yml
@@ -74,7 +74,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-branches.yml
+++ b/jobs/ci-run/integration/gen/test-branches.yml
@@ -80,7 +80,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -136,7 +136,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -188,7 +188,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -244,7 +244,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-caasadmission.yml
+++ b/jobs/ci-run/integration/gen/test-caasadmission.yml
@@ -78,7 +78,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -130,7 +130,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -182,7 +182,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-charmhub.yml
+++ b/jobs/ci-run/integration/gen/test-charmhub.yml
@@ -84,7 +84,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -140,7 +140,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -192,7 +192,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -248,7 +248,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -300,7 +300,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -356,7 +356,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-cli.yml
+++ b/jobs/ci-run/integration/gen/test-cli.yml
@@ -82,7 +82,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -134,7 +134,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -186,7 +186,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -238,7 +238,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -290,7 +290,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-constraints.yml
+++ b/jobs/ci-run/integration/gen/test-constraints.yml
@@ -76,7 +76,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -131,7 +131,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-controller.yml
+++ b/jobs/ci-run/integration/gen/test-controller.yml
@@ -80,7 +80,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -136,7 +136,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -188,7 +188,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -244,7 +244,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-deploy.yml
+++ b/jobs/ci-run/integration/gen/test-deploy.yml
@@ -84,7 +84,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -140,7 +140,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -192,7 +192,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -248,7 +248,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -300,7 +300,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -356,7 +356,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -408,7 +408,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -464,7 +464,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -516,7 +516,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -572,7 +572,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-hooks.yml
+++ b/jobs/ci-run/integration/gen/test-hooks.yml
@@ -80,7 +80,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -136,7 +136,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -188,7 +188,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -244,7 +244,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-hooktools.yml
+++ b/jobs/ci-run/integration/gen/test-hooktools.yml
@@ -76,7 +76,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -131,7 +131,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-machine.yml
+++ b/jobs/ci-run/integration/gen/test-machine.yml
@@ -76,7 +76,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -131,7 +131,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-manual.yml
+++ b/jobs/ci-run/integration/gen/test-manual.yml
@@ -80,7 +80,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -136,7 +136,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -188,7 +188,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -244,7 +244,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-model.yml
+++ b/jobs/ci-run/integration/gen/test-model.yml
@@ -88,7 +88,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -144,7 +144,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -196,7 +196,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -252,7 +252,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -304,7 +304,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -360,7 +360,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -412,7 +412,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -468,7 +468,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-network.yml
+++ b/jobs/ci-run/integration/gen/test-network.yml
@@ -80,7 +80,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -135,7 +135,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -190,7 +190,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -245,7 +245,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-relations.yml
+++ b/jobs/ci-run/integration/gen/test-relations.yml
@@ -84,7 +84,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -140,7 +140,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -192,7 +192,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -248,7 +248,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -300,7 +300,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -356,7 +356,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-resources.yml
+++ b/jobs/ci-run/integration/gen/test-resources.yml
@@ -80,7 +80,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -136,7 +136,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -188,7 +188,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -244,7 +244,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-sidecar.yml
+++ b/jobs/ci-run/integration/gen/test-sidecar.yml
@@ -76,7 +76,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -128,7 +128,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-smoke.yml
+++ b/jobs/ci-run/integration/gen/test-smoke.yml
@@ -80,7 +80,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -136,7 +136,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -188,7 +188,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -244,7 +244,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-unit.yml
+++ b/jobs/ci-run/integration/gen/test-unit.yml
@@ -76,7 +76,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -131,7 +131,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-upgrade.yml
+++ b/jobs/ci-run/integration/gen/test-upgrade.yml
@@ -74,7 +74,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-upgrade_series.yml
+++ b/jobs/ci-run/integration/gen/test-upgrade_series.yml
@@ -74,7 +74,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/tools/gen-wire-tests/main.go
+++ b/tools/gen-wire-tests/main.go
@@ -471,7 +471,7 @@ const Template = `
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:


### PR DESCRIPTION
This patch changes the timeout for the template (`make gen-wire-tests`), because we need more time for deploy_bundles_aws tests.