### PR TITLE
Added 'yq' package in test-runner.

### DIFF
--- a/jobs/ci-run/integration/common/test-runner.sh
+++ b/jobs/ci-run/integration/common/test-runner.sh
@@ -40,6 +40,9 @@ while [ $attempts -lt 3 ]; do
     if [ ! "$(which jq >/dev/null 2>&1)" ]; then
         sudo snap install jq || true
     fi
+    if [ ! "$(which yq >/dev/null 2>&1)" ]; then
+        sudo snap install yq || true
+    fi
     if [ ! "$(which shellcheck >/dev/null 2>&1)" ]; then
         sudo snap install shellcheck || true
     fi


### PR DESCRIPTION
We often start using the 'yq' tool in our tests. This patch installs it centrally not to repeat the 'yq' installation code in each test.