### PR TITLE
[JUJU-1663] Dropping Python 3.5 tests for pylibjuju

### DIFF
--- a/jobs/github/python-libjuju.yaml
+++ b/jobs/github/python-libjuju.yaml
@@ -19,9 +19,6 @@
       - python3.6:
           PYTHON_VERSION: "3.6"
           JUJU_CHANNEL: "stable"
-      - python3.5:
-          PYTHON_VERSION: "3.5"
-          JUJU_CHANNEL: "stable"
     jobs:
       - 'github-integration-tests-pylibjuju-{project_name}'
 

--- a/jobs/github/python-libjuju.yaml
+++ b/jobs/github/python-libjuju.yaml
@@ -1,7 +1,10 @@
 - project:
     name: github-integration-tests-pylibjuju
     project_name:
-      - edge:
+      - latest-edge:
+          PYTHON_VERSION: "3"
+          JUJU_CHANNEL: "latest/edge"
+      - 2.9-edge:
           PYTHON_VERSION: "3"
           JUJU_CHANNEL: "2.9/edge"
       - python3.10:

--- a/jobs/github/scripts/pylibjuju-schema-test.sh
+++ b/jobs/github/scripts/pylibjuju-schema-test.sh
@@ -9,7 +9,7 @@
 
     sudo add-apt-repository ppa:deadsnakes/ppa
     sudo apt-get update -q
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git gcc make python3.5 python3.6 python3.7 python3.8 python3-pip python3.9 python3.10
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git gcc make python3.6 python3.7 python3.8 python3-pip python3.9 python3.10
 
     # now go to libjuju and make sure it's working correctly
     mkdir -p ~/tmp

--- a/jobs/github/scripts/snippet_build_check-juju-python-libjuju.sh
+++ b/jobs/github/scripts/snippet_build_check-juju-python-libjuju.sh
@@ -7,7 +7,7 @@
 
   sudo add-apt-repository ppa:deadsnakes/ppa
   sudo apt-get update -q
-  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git gcc make python3.5 python3.6 python3.7 python3.8 python3.9 python3-pip python3.5-dev python3.6-dev python3.7-dev python3.8-dev python3.9-dev python3.9-distutils python3.10 python3.10-dev python3.10-distutils
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git gcc make python3.6 python3.7 python3.8 python3.9 python3-pip python3.6-dev python3.7-dev python3.8-dev python3.9-dev python3.9-distutils python3.10 python3.10-dev python3.10-distutils
 
   set +e  # Will fail in reports gen if any errors occur
   set -o pipefail  # Need to error for make, not tees' success.


### PR DESCRIPTION
This PR does two things:

* It is a part of our process of dropping the support for Python 3.5 for python-libjuju (:tada:). Removes the integration tests for python 3.5 for the upcoming changes to pylibjuju.
* Adds an integration test for testing python-libjuju against `juju --channel=latest/edge`. We already had a test for the channel `2.9/edge`. Now python-libjuju supporting both the `2.9` and `3.0` at the same time, this will explicitly show that it's good with both versions of Juju.