### PR TITLE
[JUJU-1713] Added expect tool installation.

### DIFF
--- a/jobs/ci-run/integration/common/test-runner.sh
+++ b/jobs/ci-run/integration/common/test-runner.sh
@@ -47,7 +47,7 @@ while [ $attempts -lt 3 ]; do
         sudo snap install shellcheck || true
     fi
     if [ ! "$(which expect >/dev/null 2>&1)" ]; then
-        sudo snap install expect || true
+        sudo apt install expect || true
     fi
     if [ ! "$(which petname >/dev/null 2>&1)" ]; then
         sudo snap install petname || true

--- a/jobs/ci-run/integration/common/test-runner.sh
+++ b/jobs/ci-run/integration/common/test-runner.sh
@@ -46,6 +46,9 @@ while [ $attempts -lt 3 ]; do
     if [ ! "$(which shellcheck >/dev/null 2>&1)" ]; then
         sudo snap install shellcheck || true
     fi
+    if [ ! "$(which expect >/dev/null 2>&1)" ]; then
+        sudo snap install expect || true
+    fi
     if [ ! "$(which petname >/dev/null 2>&1)" ]; then
         sudo snap install petname || true
     fi


### PR DESCRIPTION
The `expect` tool will help to communicate with interactive commands like: `juju change-user-password` or `juju login`. 

This is important while implementing bash-based versions of tests that strictly depend on interactive commands. 