### PR TITLE
[JUJU-1203] Add Google model tests

### DIFF
--- a/jobs/ci-run/integration/gen/test-model-unstable.yml
+++ b/jobs/ci-run/integration/gen/test-model-unstable.yml
@@ -36,11 +36,17 @@
           current-parameters: true
         - name: 'test-model-test-model-config-aws'
           current-parameters: true
+        - name: 'test-model-test-model-config-google'
+          current-parameters: true
         - name: 'test-model-test-model-metrics-lxd'
           current-parameters: true
         - name: 'test-model-test-model-metrics-aws'
           current-parameters: true
+        - name: 'test-model-test-model-metrics-google'
+          current-parameters: true
         - name: 'test-model-test-model-multi-lxd'
           current-parameters: true
         - name: 'test-model-test-model-multi-aws'
+          current-parameters: true
+        - name: 'test-model-test-model-multi-google'
           current-parameters: true

--- a/jobs/ci-run/integration/gen/test-model.yml
+++ b/jobs/ci-run/integration/gen/test-model.yml
@@ -36,21 +36,31 @@
           current-parameters: true
         - name: 'test-model-test-model-destroy-aws'
           current-parameters: true
+        - name: 'test-model-test-model-destroy-google'
+          current-parameters: true
         - name: 'test-model-test-model-migration-lxd'
           current-parameters: true
         - name: 'test-model-test-model-migration-aws'
+          current-parameters: true
+        - name: 'test-model-test-model-migration-google'
           current-parameters: true
         - name: 'test-model-test-model-migration-saas-common-lxd'
           current-parameters: true
         - name: 'test-model-test-model-migration-saas-common-aws'
           current-parameters: true
+        - name: 'test-model-test-model-migration-saas-common-google'
+          current-parameters: true
         - name: 'test-model-test-model-migration-saas-external-lxd'
           current-parameters: true
         - name: 'test-model-test-model-migration-saas-external-aws'
           current-parameters: true
+        - name: 'test-model-test-model-migration-saas-external-google'
+          current-parameters: true
         - name: 'test-model-test-model-migration-version-lxd'
           current-parameters: true
         - name: 'test-model-test-model-migration-version-aws'
+          current-parameters: true
+        - name: 'test-model-test-model-migration-version-google'
           current-parameters: true
 
 - job:
@@ -135,6 +145,62 @@
         name: BOOTSTRAP_PROVIDER
     - string:
         default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 50
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'model'
+            setup_steps: ''
+            task_name: 'test_model_config'
+            skip_tasks: 'test_model_destroy,test_model_metrics,test_model_migration,test_model_migration_saas_common,test_model_migration_saas_external,test_model_migration_version,test_model_multi'
+
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-model-test-model-config-google
+    node: ephemeral-focal-small-amd64
+    description: |-
+      Test test_model_config in model suite on google
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'google'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'google'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
     - string:
@@ -270,6 +336,62 @@
       - integration-artifacts
 
 - job:
+    name: test-model-test-model-destroy-google
+    node: ephemeral-focal-small-amd64
+    description: |-
+      Test test_model_destroy in model suite on google
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'google'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'google'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 50
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'model'
+            setup_steps: ''
+            task_name: 'test_model_destroy'
+            skip_tasks: 'test_model_config,test_model_metrics,test_model_migration,test_model_migration_saas_common,test_model_migration_saas_external,test_model_migration_version,test_model_multi'
+
+    publishers:
+      - integration-artifacts
+
+- job:
     name: test-model-test-model-metrics-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
@@ -351,6 +473,62 @@
         name: BOOTSTRAP_PROVIDER
     - string:
         default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 50
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'model'
+            setup_steps: ''
+            task_name: 'test_model_metrics'
+            skip_tasks: 'test_model_config,test_model_destroy,test_model_migration,test_model_migration_saas_common,test_model_migration_saas_external,test_model_migration_version,test_model_multi'
+
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-model-test-model-metrics-google
+    node: ephemeral-focal-small-amd64
+    description: |-
+      Test test_model_metrics in model suite on google
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'google'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'google'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
     - string:
@@ -486,6 +664,62 @@
       - integration-artifacts
 
 - job:
+    name: test-model-test-model-migration-google
+    node: ephemeral-focal-small-amd64
+    description: |-
+      Test test_model_migration in model suite on google
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'google'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'google'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 90
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'model'
+            setup_steps: ''
+            task_name: 'test_model_migration'
+            skip_tasks: 'test_model_config,test_model_destroy,test_model_metrics,test_model_migration_saas_common,test_model_migration_saas_external,test_model_migration_version,test_model_multi'
+
+    publishers:
+      - integration-artifacts
+
+- job:
     name: test-model-test-model-migration-saas-common-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
@@ -567,6 +801,62 @@
         name: BOOTSTRAP_PROVIDER
     - string:
         default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 50
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'model'
+            setup_steps: ''
+            task_name: 'test_model_migration_saas_common'
+            skip_tasks: 'test_model_config,test_model_destroy,test_model_metrics,test_model_migration,test_model_migration_saas_external,test_model_migration_version,test_model_multi'
+
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-model-test-model-migration-saas-common-google
+    node: ephemeral-focal-small-amd64
+    description: |-
+      Test test_model_migration_saas_common in model suite on google
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'google'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'google'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
     - string:
@@ -702,6 +992,62 @@
       - integration-artifacts
 
 - job:
+    name: test-model-test-model-migration-saas-external-google
+    node: ephemeral-focal-small-amd64
+    description: |-
+      Test test_model_migration_saas_external in model suite on google
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'google'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'google'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 50
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'model'
+            setup_steps: ''
+            task_name: 'test_model_migration_saas_external'
+            skip_tasks: 'test_model_config,test_model_destroy,test_model_metrics,test_model_migration,test_model_migration_saas_common,test_model_migration_version,test_model_multi'
+
+    publishers:
+      - integration-artifacts
+
+- job:
     name: test-model-test-model-migration-version-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
@@ -810,6 +1156,62 @@
       - integration-artifacts
 
 - job:
+    name: test-model-test-model-migration-version-google
+    node: ephemeral-focal-small-amd64
+    description: |-
+      Test test_model_migration_version in model suite on google
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'google'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'google'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 50
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'model'
+            setup_steps: ''
+            task_name: 'test_model_migration_version'
+            skip_tasks: 'test_model_config,test_model_destroy,test_model_metrics,test_model_migration,test_model_migration_saas_common,test_model_migration_saas_external,test_model_multi'
+
+    publishers:
+      - integration-artifacts
+
+- job:
     name: test-model-test-model-multi-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
@@ -891,6 +1293,62 @@
         name: BOOTSTRAP_PROVIDER
     - string:
         default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 50
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'model'
+            setup_steps: ''
+            task_name: 'test_model_multi'
+            skip_tasks: 'test_model_config,test_model_destroy,test_model_metrics,test_model_migration,test_model_migration_saas_common,test_model_migration_saas_external,test_model_migration_version'
+
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-model-test-model-multi-google
+    node: ephemeral-focal-small-amd64
+    description: |-
+      Test test_model_multi in model suite on google
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'google'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'google'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
     - string:

--- a/tools/gen-wire-tests/juju.config
+++ b/tools/gen-wire-tests/juju.config
@@ -19,6 +19,10 @@ folders:
         - test_model_config
         - test_model_multi
         - test_model_metrics
+      google:
+        - test_model_config
+        - test_model_multi
+        - test_model_metrics
     user:
       lxd:
         - test_user_login_password
@@ -63,7 +67,6 @@ folders:
     - hooktools
     - machine
     - manual
-    - model
     - relations
     - resources
     - sidecar


### PR DESCRIPTION
Particularly model migration to resolve JUJU-1203, but also add destroy test as a driveby

QA Steps:
```
SHORT_GIT_COMMIT="45757f4" BOOTSTRAP_PROVIDER=google BOOTSTRAP_CLOUD=google ./main.sh -v -s 'test_model_config,test_model_multi,test_model_metrics' model
```