### PR TITLE
Install grepcidr on workers

### DIFF
--- a/jobs/ci-run/integration/common/test-runner.sh
+++ b/jobs/ci-run/integration/common/test-runner.sh
@@ -49,6 +49,9 @@ while [ $attempts -lt 3 ]; do
     if [ ! "$(which petname >/dev/null 2>&1)" ]; then
         sudo snap install petname || true
     fi
+	if [ ! "$(which grepcidr >/dev/null 2>&1)" ]; then
+		sudo apt install grepcidr -y
+	fi
     # shellcheck disable=SC2193
     if [ "${{BOOTSTRAP_PROVIDER:-}}" = "aws" ]; then
         if [ ! "$(which aws >/dev/null 2>&1)" ]; then


### PR DESCRIPTION
`grepcidr` is a lightweight tool from the universe repository we can use to determine weather an ip is within a cidr range

This will be used for our spaces test, and likely will have some other applications