### PR TITLE
[JUJU-1189]remove old nw-assess-persistent-storage gating tests left behind

### DIFF
--- a/jobs/ci-run/functional/gating-functional-tests.yml
+++ b/jobs/ci-run/functional/gating-functional-tests.yml
@@ -29,8 +29,6 @@
           projects:
             # These projects are currently in alphabetical order.
             # Please keep it that way!
-            - name: nw-assess-persistent-storage
-              current-parameters: true
             - name: nw-deploy-bionic-gke
               current-parameters: true
             - name: nw-deploy-bionic-aks


### PR DESCRIPTION
This PR removes the last of the nw-assess-persistent storage (gating) tests left behind. This is a mistake on my part, I forgot to remove it in this [PR](https://github.com/juju/juju-qa-jenkins/pull/82).