### PR TITLE
Install plugin juju-kubectl into jenkins

### DIFF
--- a/jobs/ci-run/integration/common/test-runner.sh
+++ b/jobs/ci-run/integration/common/test-runner.sh
@@ -46,6 +46,9 @@ while [ $attempts -lt 3 ]; do
     if [ ! "$(which shellcheck >/dev/null 2>&1)" ]; then
         sudo snap install shellcheck || true
     fi
+    if [ ! "$(which juju-kubectl >/dev/null 2>&1)" ]; then
+        sudo snap install juju-kubectl --classic || true
+    fi
     if [ ! "$(which expect >/dev/null 2>&1)" ]; then
         sudo apt-get -y install expect || true
     fi


### PR DESCRIPTION
This tool will be used to introspect a k8s. It allows kubectl to be run against a cluster with a juju model without needing to setup config and across cluster providers