### PR TITLE
Fix ecr repo charm-base images, move tests to proving grounds + add proving grounds daily trigger.

### DIFF
--- a/jobs/ci-run/ci-run-master.yml
+++ b/jobs/ci-run/ci-run-master.yml
@@ -276,8 +276,8 @@
                 BOOTSTRAP_SERIES=${BOOTSTRAP_SERIES}
     publishers:
       - trigger-parameterized-builds:
-          - project: "ci-proving-ground-tests"
-            condition: SUCCESS
+          - project: "ci-proving-ground-tests-once-daily"
+            condition: ALWAYS
             current-parameters: true
             predefined-parameters: |-
               series=${series}

--- a/jobs/ci-run/ci-run-proving-grounds-tests.yml
+++ b/jobs/ci-run/ci-run-proving-grounds-tests.yml
@@ -24,12 +24,12 @@
           description: "Series to use with charms in the functional tests"
           name: series
       - string:
-          default: ''
-          description: 'Ubuntu series to use when bootstrapping Juju'
+          default: ""
+          description: "Ubuntu series to use when bootstrapping Juju"
           name: BOOTSTRAP_SERIES
       - string:
-          default: ''
-          description: 'Go version used for build.'
+          default: ""
+          description: "Go version used for build."
           name: GOVERSION
     builders:
       - get-build-details
@@ -44,3 +44,62 @@
             - name: proving-grounds-integration-tests-amd64
               current-parameters: true
               predefined-parameters: BUILD_ARCH=arm64
+
+- job:
+    name: "ci-proving-ground-tests-once-daily"
+    project-type: "multijob"
+    description: "Run proving ground tests for a Juju commit once per day"
+    condition: SUCCESSFUL
+    node: noop-parent-jobs
+    concurrent: false
+    parameters:
+      - validating-string:
+          description: The git short hash for the commit you wish to test
+          name: SHORT_GIT_COMMIT
+          regex: ^\S{7}$
+          msg: Enter a valid 7 char git sha
+      - string:
+          default: ""
+          description: "Series to use with charms in the functional tests"
+          name: series
+      - string:
+          default: ""
+          description: "Ubuntu series to use when bootstrapping Juju"
+          name: BOOTSTRAP_SERIES
+      - string:
+          default: ""
+          description: "Go version used for build."
+          name: GOVERSION
+    builders:
+      - get-build-details
+      - set-test-description
+      - system-groovy:
+          command: |
+            import hudson.model.*
+
+            def b = build.getPreviousBuild()
+            while (b != null) {
+                if (b.number == 22) {
+                    // handle first build
+                    break
+                }
+                if (b.result != Result.SUCCESS) {
+                    b = b.getPreviousBuild()
+                    continue
+                }
+                if (b.getStartTimeInMillis()+(24*60*60*1000)>build.getStartTimeInMillis()) {
+                    throw new InterruptedException()
+                }
+                break
+            }
+
+            println "It has been one day since last build... triggering job"
+    publishers:
+      - trigger-parameterized-builds:
+          - project: "ci-proving-ground-tests"
+            condition: SUCCESS
+            current-parameters: true
+            predefined-parameters: |-
+              series=${series}
+              SHORT_GIT_COMMIT=${SHORT_GIT_COMMIT}
+              GOVERSION=${GOVERSION}

--- a/jobs/ci-run/integration/common/registry-setup.sh
+++ b/jobs/ci-run/integration/common/registry-setup.sh
@@ -2,10 +2,10 @@
 set -eux
 
 if ! [ -x "$(command -v aws)" ]; then
-    sudo snap install aws-cli --classic || true
+  sudo snap install aws-cli --classic || true
 fi
 
-REGION="${REGION:-ap-southeast-2}"
+REGION="${REGION:-us-east-1}"
 DOCKER_REGISTRY="$(aws ecr describe-registry --region "${REGION}" | jq -r '.registryId').dkr.ecr.${REGION}.amazonaws.com"
 REPOSITORY_NAME_PREFIX="${JOB_NAME}-${JUJU_BUILD_NUMBER}"
 OPERATOR_IMAGE_ACCOUNT="${DOCKER_REGISTRY}/${REPOSITORY_NAME_PREFIX}"
@@ -13,6 +13,7 @@ OPERATOR_IMAGE_ACCOUNT="${DOCKER_REGISTRY}/${REPOSITORY_NAME_PREFIX}"
 ECR_TOKEN=$(aws ecr get-login-password --region "${REGION}")
 aws ecr create-repository --repository-name "${REPOSITORY_NAME_PREFIX}/jujud-operator" || true
 aws ecr create-repository --repository-name "${REPOSITORY_NAME_PREFIX}/juju-db" || true
+aws ecr create-repository --repository-name "${REPOSITORY_NAME_PREFIX}/charm-base" || true
 
 JUJU_DB_TAG=$(grep -r 'DefaultJujuDBSnapChannel =' "${JUJU_SRC_PATH}/controller/config.go" | sed -r 's/^\s*DefaultJujuDBSnapChannel = \"([[:digit:]]+\.[[:digit:]]+(\.[[:digit:]]+){0,1})\/.*\"$/\1/')
 
@@ -25,9 +26,18 @@ export JUJU_DB_TAG
 echo "${ECR_TOKEN}" | docker login -u AWS --password-stdin "${DOCKER_REGISTRY}"
 DOCKER_USERNAME=${OPERATOR_IMAGE_ACCOUNT} make -C "${JUJU_SRC_PATH}" push-release-operator-image
 
+# Copy juju-db from docker
 docker pull "jujusolutions/juju-db:${JUJU_DB_TAG}"
 docker tag "jujusolutions/juju-db:${JUJU_DB_TAG}" "${OPERATOR_IMAGE_ACCOUNT}/juju-db:${JUJU_DB_TAG}"
 docker push "${OPERATOR_IMAGE_ACCOUNT}/juju-db:${JUJU_DB_TAG}"
+
+# Copy LTS charm bases from docker
+BASES=(18.04 20.04 22.04)
+for BASE in "${BASES[@]}" ; do
+  docker pull "jujusolutions/charm-base:ubuntu-${BASE}"
+  docker tag "jujusolutions/charm-base:ubuntu-${BASE}" "${OPERATOR_IMAGE_ACCOUNT}/charm-base:ubuntu-${BASE}"
+  docker push "${OPERATOR_IMAGE_ACCOUNT}/charm-base:ubuntu-${BASE}"
+done
 
 set +x
 OPERATOR_IMAGE_ACCOUNT=$(jq -r --null-input \

--- a/jobs/ci-run/integration/integrationtests.yml
+++ b/jobs/ci-run/integration/integrationtests.yml
@@ -122,10 +122,6 @@
               current-parameters: true
               predefined-parameters: |-
                 BUILD_ARCH=amd64
-            - name: 'test-deploy_caas-multijob'
-              current-parameters: true
-              predefined-parameters: |-
-                BUILD_ARCH=amd64
             - name: 'test-expose_ec2-multijob'
               current-parameters: true
               predefined-parameters: |-
@@ -139,10 +135,6 @@
               predefined-parameters: |-
                 BUILD_ARCH=amd64
             - name: 'test-machine-multijob'
-              current-parameters: true
-              predefined-parameters: |-
-                BUILD_ARCH=amd64
-            - name: 'test-magma-multijob'
               current-parameters: true
               predefined-parameters: |-
                 BUILD_ARCH=amd64
@@ -245,6 +237,14 @@
               predefined-parameters: |-
                 BUILD_ARCH=amd64
             - name: 'test-manual-multijob'
+              current-parameters: true
+              predefined-parameters: |-
+                BUILD_ARCH=amd64
+            - name: 'test-magma-multijob'
+              current-parameters: true
+              predefined-parameters: |-
+                BUILD_ARCH=amd64
+            - name: 'test-deploy_caas-multijob'
               current-parameters: true
               predefined-parameters: |-
                 BUILD_ARCH=amd64

--- a/jobs/ci-run/utils.yml
+++ b/jobs/ci-run/utils.yml
@@ -384,7 +384,7 @@
         sudo cp -R "$JUJU_DATA/credentials.yaml" "$juju_data"
         sudo chown -R "$USER" "$juju_data"
 
-        REGION="${REGION:-ap-southeast-2}"
+        REGION="${REGION:-us-east-1}"
 
         mkdir -p "$HOME"/.aws
         echo "[default]" > "$HOME"/.aws/credentials

--- a/tests/suites/static_analysis/lint_yaml.sh
+++ b/tests/suites/static_analysis/lint_yaml.sh
@@ -41,6 +41,7 @@ jobs:
     - ci-build-juju
     - ci-gating-tests
     - ci-proving-ground-tests
+    - ci-proving-ground-tests-once-daily
     - clean-lxd-environments
     - clean-maas-environments
     - clean-workspaces


### PR DESCRIPTION
- Fix ECR repo not having charm-base images copied.
- Move test-magma-multijob, test-deploy_caas-multijob to proving grounds.
- Setup ci-proving-ground-tests-once-daily to trigger ci-proving-ground-tests only once per day.