### PR TITLE
[JUJU-1996] Fixed magma test jenkins job description

### DIFF
--- a/jobs/ci-run/integration/gen/test-magma.yml
+++ b/jobs/ci-run/integration/gen/test-magma.yml
@@ -74,7 +74,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 100
           fail: true
           type: absolute
     builders:

--- a/tools/gen-wire-tests/juju.config
+++ b/tools/gen-wire-tests/juju.config
@@ -2,6 +2,8 @@ folders:
   timeout:
     model:
       test_model_migration: 90
+    magma:
+      default: 90
   unstable:
     deploy:
       lxd:

--- a/tools/gen-wire-tests/juju.config
+++ b/tools/gen-wire-tests/juju.config
@@ -3,7 +3,7 @@ folders:
     model:
       test_model_migration: 90
     magma:
-      default: 90
+      default: 100
   unstable:
     deploy:
       lxd:

--- a/tools/gen-wire-tests/main.go
+++ b/tools/gen-wire-tests/main.go
@@ -427,7 +427,7 @@ const Template = `
     {{- end }}
 
 {{- if eq $node.Unstable false }}
-{{$timeout := (index $node.Timeout $task_name)}}
+{{$timeout := (index $node.Timeout $task_name)}} {{$d_timeout := (index $node.Timeout "default")}}
 - job:
     name: {{$full_task_name}}
     node: {{$run_on}}
@@ -477,7 +477,7 @@ const Template = `
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: {{- if gt $timeout 0 }} {{$timeout}}{{ else }} 50{{- end}}
+          timeout: {{- if gt $timeout 0 }} {{$timeout}}{{ else }} {{- if gt $d_timeout 0 }} {{$d_timeout}}{{ else }} 50{{- end}}{{- end}}
           fail: true
           type: absolute
     builders:

--- a/tools/gen-wire-tests/main.go
+++ b/tools/gen-wire-tests/main.go
@@ -427,7 +427,7 @@ const Template = `
     {{- end }}
 
 {{- if eq $node.Unstable false }}
-{{$timeout := (index $node.Timeout $task_name)}} {{$d_timeout := (index $node.Timeout "default")}}
+{{$timeout := (index $node.Timeout $task_name)}} {{- $d_timeout := (index $node.Timeout "default")}}
 - job:
     name: {{$full_task_name}}
     node: {{$run_on}}


### PR DESCRIPTION
This job requires more time to complete.

This PR adds the possibility to define a default timeout for each suite. So now you can use a particular timeout for each test, a default timeout for a test suite, or use default timeout that is hardcoded in the template.