### PR TITLE
Create ~/.local/share dir before running Juju

### DIFF
--- a/jobs/github/scripts/pylibjuju-integration-test.sh
+++ b/jobs/github/scripts/pylibjuju-integration-test.sh
@@ -57,6 +57,10 @@ while [ $attempts -lt 3 ]; do
     attempts=$((attempts + 1))
 done
 
+# As Juju is now sometimes a strictly confined snap, it needs to be helped
+# out by creating the ~/.local/share dir as it cannot do this itself
+mkdir -p $HOME/.local/share
+
 juju bootstrap localhost test \
     --config 'identity-url=https://api.staging.jujucharms.com/identity' \
     --config 'allow-model-access=true' \


### PR DESCRIPTION
In it's current state, when installing Juju from a strictly confined snap, it does not have permission to create this directory if it is absent

Ensure it exists by creating it beforehand

Resolves:
https://bugs.launchpad.net/juju/+bug/1988355