### PR TITLE
[JUJU-2057] Decreased common timeout to 30 mins.

### DIFF
--- a/jobs/ci-run/integration/gen/test-agents.yml
+++ b/jobs/ci-run/integration/gen/test-agents.yml
@@ -94,7 +94,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -167,7 +167,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-appdata.yml
+++ b/jobs/ci-run/integration/gen/test-appdata.yml
@@ -94,7 +94,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -167,7 +167,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-backup.yml
+++ b/jobs/ci-run/integration/gen/test-backup.yml
@@ -94,7 +94,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -167,7 +167,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-bootstrap.yml
+++ b/jobs/ci-run/integration/gen/test-bootstrap.yml
@@ -92,7 +92,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-branches.yml
+++ b/jobs/ci-run/integration/gen/test-branches.yml
@@ -98,7 +98,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -172,7 +172,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -242,7 +242,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -316,7 +316,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-caasadmission.yml
+++ b/jobs/ci-run/integration/gen/test-caasadmission.yml
@@ -96,7 +96,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -166,7 +166,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -236,7 +236,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-charmhub.yml
+++ b/jobs/ci-run/integration/gen/test-charmhub.yml
@@ -102,7 +102,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -176,7 +176,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -246,7 +246,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -320,7 +320,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -390,7 +390,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -464,7 +464,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-cli.yml
+++ b/jobs/ci-run/integration/gen/test-cli.yml
@@ -100,7 +100,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -170,7 +170,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -240,7 +240,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -310,7 +310,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -380,7 +380,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-cmr.yml
+++ b/jobs/ci-run/integration/gen/test-cmr.yml
@@ -94,7 +94,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -167,7 +167,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-constraints.yml
+++ b/jobs/ci-run/integration/gen/test-constraints.yml
@@ -94,7 +94,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -167,7 +167,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-controller.yml
+++ b/jobs/ci-run/integration/gen/test-controller.yml
@@ -98,7 +98,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -172,7 +172,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -242,7 +242,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -316,7 +316,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-coslite.yml
+++ b/jobs/ci-run/integration/gen/test-coslite.yml
@@ -92,7 +92,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-credential.yml
+++ b/jobs/ci-run/integration/gen/test-credential.yml
@@ -94,7 +94,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -167,7 +167,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-deploy.yml
+++ b/jobs/ci-run/integration/gen/test-deploy.yml
@@ -106,7 +106,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -180,7 +180,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -394,7 +394,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -468,7 +468,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -538,7 +538,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -612,7 +612,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -682,7 +682,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -756,7 +756,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -826,7 +826,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -900,7 +900,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-deploy_caas.yml
+++ b/jobs/ci-run/integration/gen/test-deploy_caas.yml
@@ -92,7 +92,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-expose_ec2.yml
+++ b/jobs/ci-run/integration/gen/test-expose_ec2.yml
@@ -98,7 +98,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -172,7 +172,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-hooks.yml
+++ b/jobs/ci-run/integration/gen/test-hooks.yml
@@ -98,7 +98,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -172,7 +172,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -242,7 +242,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -316,7 +316,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-hooktools.yml
+++ b/jobs/ci-run/integration/gen/test-hooktools.yml
@@ -94,7 +94,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -167,7 +167,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-machine.yml
+++ b/jobs/ci-run/integration/gen/test-machine.yml
@@ -94,7 +94,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -167,7 +167,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-manual.yml
+++ b/jobs/ci-run/integration/gen/test-manual.yml
@@ -98,7 +98,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -172,7 +172,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -242,7 +242,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -316,7 +316,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-model.yml
+++ b/jobs/ci-run/integration/gen/test-model.yml
@@ -120,7 +120,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -194,7 +194,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -268,7 +268,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -338,7 +338,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -412,7 +412,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -486,7 +486,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -556,7 +556,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -630,7 +630,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -704,7 +704,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -992,7 +992,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -1066,7 +1066,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -1140,7 +1140,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -1210,7 +1210,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -1284,7 +1284,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -1358,7 +1358,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -1646,7 +1646,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -1720,7 +1720,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -1794,7 +1794,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-network.yml
+++ b/jobs/ci-run/integration/gen/test-network.yml
@@ -98,7 +98,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -171,7 +171,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -244,7 +244,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -317,7 +317,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-refresh.yml
+++ b/jobs/ci-run/integration/gen/test-refresh.yml
@@ -110,7 +110,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -184,7 +184,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -258,7 +258,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -332,7 +332,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -402,7 +402,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -472,7 +472,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -546,7 +546,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -620,7 +620,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -694,7 +694,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -764,7 +764,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-relations.yml
+++ b/jobs/ci-run/integration/gen/test-relations.yml
@@ -102,7 +102,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -176,7 +176,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -246,7 +246,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -320,7 +320,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -390,7 +390,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -464,7 +464,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-resources.yml
+++ b/jobs/ci-run/integration/gen/test-resources.yml
@@ -98,7 +98,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -172,7 +172,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -242,7 +242,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -316,7 +316,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-sidecar.yml
+++ b/jobs/ci-run/integration/gen/test-sidecar.yml
@@ -94,7 +94,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -164,7 +164,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-smoke.yml
+++ b/jobs/ci-run/integration/gen/test-smoke.yml
@@ -98,7 +98,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -172,7 +172,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -242,7 +242,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -316,7 +316,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-spaces_ec2.yml
+++ b/jobs/ci-run/integration/gen/test-spaces_ec2.yml
@@ -100,7 +100,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -174,7 +174,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -248,7 +248,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-storage.yml
+++ b/jobs/ci-run/integration/gen/test-storage.yml
@@ -98,7 +98,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -172,7 +172,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-unit.yml
+++ b/jobs/ci-run/integration/gen/test-unit.yml
@@ -94,7 +94,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -167,7 +167,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-upgrade.yml
+++ b/jobs/ci-run/integration/gen/test-upgrade.yml
@@ -92,7 +92,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-upgrade_series.yml
+++ b/jobs/ci-run/integration/gen/test-upgrade_series.yml
@@ -92,7 +92,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/jobs/ci-run/integration/gen/test-user.yml
+++ b/jobs/ci-run/integration/gen/test-user.yml
@@ -94,7 +94,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -168,7 +168,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -238,7 +238,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
@@ -312,7 +312,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:

--- a/tools/gen-wire-tests/juju.config
+++ b/tools/gen-wire-tests/juju.config
@@ -2,8 +2,11 @@ folders:
   timeout:
     model:
       test_model_migration: 90
+      test_model_migration_version: 50
     magma:
       test_deploy_magma: 90
+    deploy:
+      test_deploy_bundles: 50
   unstable:
     deploy:
       lxd:

--- a/tools/gen-wire-tests/main.go
+++ b/tools/gen-wire-tests/main.go
@@ -487,7 +487,7 @@ const Template = `
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: {{- if gt $timeout 0 }} {{$timeout}}{{ else }} 50{{- end}}
+          timeout: {{- if gt $timeout 0 }} {{$timeout}}{{ else }} 30{{- end}}
           fail: true
           type: absolute
     builders:


### PR DESCRIPTION
This PR decreases the common timeout for each integration test from 50 mins to 30 mins.
At the same time, it provides custom timeouts for each "long" integration test.

```
timeout:
    model:
      test_model_migration: 90
      test_model_migration_version: 50
    magma:
      test_deploy_magma: 90
    deploy:
      test_deploy_bundles: 50
```