### PR TITLE
[JUJU-1843] install-microk8s builder now takes a channel param

### DIFF
--- a/jobs/ci-run/integration/builders.yaml
+++ b/jobs/ci-run/integration/builders.yaml
@@ -35,7 +35,8 @@
     builders:
     - wait-for-cloud-init
     - prepare-integration-test
-    - install-microk8s
+    - install-microk8s:
+        channel: "latest/stable"
     - install-docker
     - ensure-aws-credentials
     - registry-setup

--- a/jobs/common/pre-reqs.yaml
+++ b/jobs/common/pre-reqs.yaml
@@ -70,8 +70,8 @@
         set -ex
 
         # Install microk8s and kubectl
-        sudo snap install microk8s --classic
-        sudo snap install kubectl --classic
+        sudo snap install microk8s --classic --channel={channel}
+        sudo snap install kubectl --classic --channel={channel}
         echo "waiting for microk8s storage to become available"
         NEXT_WAIT_TIME=0
         until [ $NEXT_WAIT_TIME -eq 30 ] || sudo microk8s enable dns hostpath-storage && microk8s status --yaml | grep -q 'storage: enabled'; do


### PR DESCRIPTION
At the moment, the only time this builder is called uses the default latest/stable channel. This change is in anticipation of a future requirement of charmed-kubeflow, which only supports specific versions of kubernetes

https://charmed-kubeflow.io/docs/install