### PR TITLE
Add Kubeflow integration tests pipeline to proving grounds

### DIFF
--- a/jobs/ci-run/integration/integrationtests.yml
+++ b/jobs/ci-run/integration/integrationtests.yml
@@ -228,19 +228,11 @@
       - multijob:
           name: proving-grounds-integration-tests-amd64
           projects:
+            - name: 'test-coslite-multijob'
+              current-parameters: true
+              predefined-parameters: |-
+                BUILD_ARCH=amd64
             - name: 'test-deploy-unstable-multijob'
-              current-parameters: true
-              predefined-parameters: |-
-                BUILD_ARCH=amd64
-            - name: 'test-model-unstable-multijob'
-              current-parameters: true
-              predefined-parameters: |-
-                BUILD_ARCH=amd64
-            - name: 'test-user-unstable-multijob'
-              current-parameters: true
-              predefined-parameters: |-
-                BUILD_ARCH=amd64
-            - name: 'test-magma-multijob'
               current-parameters: true
               predefined-parameters: |-
                 BUILD_ARCH=amd64
@@ -248,7 +240,15 @@
               current-parameters: true
               predefined-parameters: |-
                 BUILD_ARCH=amd64
-            - name: 'test-coslite-multijob'
+            - name: 'test-kubeflow'
+              current-parameters: true
+              predefined-parameters: |-
+                BUILD_ARCH=amd64
+            - name: 'test-magma-multijob'
+              current-parameters: true
+              predefined-parameters: |-
+                BUILD_ARCH=amd64
+            - name: 'test-model-unstable-multijob'
               current-parameters: true
               predefined-parameters: |-
                 BUILD_ARCH=amd64
@@ -257,6 +257,10 @@
               predefined-parameters: |-
                 BUILD_ARCH=amd64
             - name: 'test-secrets_k8s-multijob'
+              current-parameters: true
+              predefined-parameters: |-
+                BUILD_ARCH=amd64
+            - name: 'test-user-unstable-multijob'
               current-parameters: true
               predefined-parameters: |-
                 BUILD_ARCH=amd64

--- a/jobs/ci-run/integration/man/test-kubeflow.yml
+++ b/jobs/ci-run/integration/man/test-kubeflow.yml
@@ -1,0 +1,81 @@
+- job:
+    name: test-kubeflow
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test kubeflow suite on microk8s
+    condition: SUCCESSFUL
+    concurrent: true
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'microk8s'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'k8s'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 50
+          fail: true
+          type: absolute
+    builders:
+      - wait-for-cloud-init
+      - prepare-integration-test
+      - install-microk8s:
+          channel: "1.22/stable"
+      - install-docker
+      - install-charmcraft
+      - ensure-aws-credentials
+      - registry-setup
+      - get-s3-build-payload-testing:
+            SHORT_GIT_COMMIT: "${{SHORT_GIT_COMMIT}}"
+            platform: "linux/${{BUILD_ARCH}}"
+      - integration-test-runner:
+            test_name: "kubeflow"
+            task_name: ""
+            skip_tasks: ""
+            setup_steps: ""
+    publishers:
+      - integration-artifacts

--- a/jobs/common/pre-reqs.yaml
+++ b/jobs/common/pre-reqs.yaml
@@ -63,6 +63,14 @@
         !include-raw: "scripts/install-go.sh"
 
 - builder:
+    name: install-charmcraft
+    builders:
+    - shell: |-
+        #!/bin/bash
+        set -ex
+        sudo snap install charmcraft --classic --channel=latest/stable
+
+- builder:
     name: install-microk8s
     builders:
     - shell: |-

--- a/tools/gen-wire-tests/juju.config
+++ b/tools/gen-wire-tests/juju.config
@@ -41,6 +41,7 @@ folders:
     - ovs_maas
     - static_analysis
     - ck
+    - kubeflow
   skip-lxd:
     - caasadmission
     - coslite


### PR DESCRIPTION
This suite needed to be added manually for the time being because
charmed kubeflow only supports k8s 1.22

Also re-alphabetise proving grounds multijob