### PR TITLE
Add another linter which asserts multijobs are alphabetical

### DIFF
--- a/jobs/ci-run/ci-run-master.yml
+++ b/jobs/ci-run/ci-run-master.yml
@@ -262,11 +262,6 @@
           name: "Testing"
           condition: SUCCESSFUL
           projects:
-            - name: "unit-tests"
-              current-parameters: true
-              predefined-parameters: |-
-                SHORT_GIT_COMMIT=${SHORT_GIT_COMMIT}
-                GOVERSION=${GOVERSION}
             - name: "gating-tests"
               current-parameters: true
               predefined-parameters: |-
@@ -274,6 +269,11 @@
                 series=${series}
                 GOVERSION=${GOVERSION}
                 BOOTSTRAP_SERIES=${BOOTSTRAP_SERIES}
+            - name: "unit-tests"
+              current-parameters: true
+              predefined-parameters: |-
+                SHORT_GIT_COMMIT=${SHORT_GIT_COMMIT}
+                GOVERSION=${GOVERSION}
     publishers:
       - trigger-parameterized-builds:
           - project: "ci-proving-ground-tests-once-daily"

--- a/jobs/ci-run/functional/gating-functional-tests.yml
+++ b/jobs/ci-run/functional/gating-functional-tests.yml
@@ -27,11 +27,9 @@
       - multijob:
           name: GatingFunctionalTestsAmd64
           projects:
-            # These projects are currently in alphabetical order.
-            # Please keep it that way!
-            - name: nw-deploy-bionic-gke
-              current-parameters: true
             - name: nw-deploy-bionic-aks
+              current-parameters: true
+            - name: nw-deploy-bionic-gke
               current-parameters: true
             - name: nw-deploy-bionic-microk8s
               disabled: true # nameserver fix required on microk8s

--- a/jobs/ci-run/functional/proving-grounds-functional-tests.yml
+++ b/jobs/ci-run/functional/proving-grounds-functional-tests.yml
@@ -22,16 +22,20 @@
       - multijob:
           name: ProvingGroundsFunctionalTestsAmd64
           projects:
-            - name: nw-deploy-jammy-amd64-equinix
-              current-parameters: true
-              enable-condition: '!["2.8"].contains("${JUJU_VERSION_MAJOR_MINOR}")' # Provider support is only available on 2.9+
-            - name: nw-deploy-focal-amd64-lxd
-              current-parameters: true
-            - name: nw-deploy-jammy-amd64-lxd
+            - name: nw-add-cloud-many
               current-parameters: true
             - name: nw-deploy-bionic-eks
               current-parameters: true
-            - name: nw-upgrade-juju-beta
+            - name: nw-deploy-client-centos9
+              current-parameters: true
+            - name: nw-deploy-client-windows
+              current-parameters: true
+            - name: nw-deploy-focal-amd64-lxd
+              current-parameters: true
+            - name: nw-deploy-jammy-amd64-equinix
+              current-parameters: true
+              enable-condition: '!["2.8"].contains("${JUJU_VERSION_MAJOR_MINOR}")' # Provider support is only available on 2.9+
+            - name: nw-deploy-jammy-amd64-lxd
               current-parameters: true
             - name: nw-deploy-kubeflow
               alias: nw-kubeflow-microk8s-lite-rbac
@@ -41,9 +45,5 @@
                 BUNDLE_VERSION=lite
                 BUILD_CHARMS=false
                 ENABLE_RBAC=true
-            - name: nw-add-cloud-many
-              current-parameters: true
-            - name: nw-deploy-client-centos9
-              current-parameters: true
-            - name: nw-deploy-client-windows
+            - name: nw-upgrade-juju-beta
               current-parameters: true

--- a/jobs/ci-run/integration/gen/test-agents.yml
+++ b/jobs/ci-run/integration/gen/test-agents.yml
@@ -32,79 +32,10 @@
     - multijob:
         name: 'IntegrationTests-agents'
         projects:
-        - name: 'test-agents-test-charmrevisionupdater-lxd'
-          current-parameters: true
         - name: 'test-agents-test-charmrevisionupdater-aws'
           current-parameters: true
-
-- job:
-    name: test-agents-test-charmrevisionupdater-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test agents suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'agents'
-            setup_steps: ''
-            task_name: ''
-            skip_tasks: ''
-    publishers:
-      - integration-artifacts
+        - name: 'test-agents-test-charmrevisionupdater-lxd'
+          current-parameters: true
 
 - job:
     name: test-agents-test-charmrevisionupdater-aws
@@ -156,6 +87,75 @@
         default: 'us-east-1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'agents'
+            setup_steps: ''
+            task_name: ''
+            skip_tasks: ''
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-agents-test-charmrevisionupdater-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test agents suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-appdata.yml
+++ b/jobs/ci-run/integration/gen/test-appdata.yml
@@ -32,79 +32,10 @@
     - multijob:
         name: 'IntegrationTests-appdata'
         projects:
-        - name: 'test-appdata-test-appdata-int-lxd'
-          current-parameters: true
         - name: 'test-appdata-test-appdata-int-aws'
           current-parameters: true
-
-- job:
-    name: test-appdata-test-appdata-int-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test appdata suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'appdata'
-            setup_steps: ''
-            task_name: ''
-            skip_tasks: ''
-    publishers:
-      - integration-artifacts
+        - name: 'test-appdata-test-appdata-int-lxd'
+          current-parameters: true
 
 - job:
     name: test-appdata-test-appdata-int-aws
@@ -156,6 +87,75 @@
         default: 'us-east-1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'appdata'
+            setup_steps: ''
+            task_name: ''
+            skip_tasks: ''
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-appdata-test-appdata-int-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test appdata suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-backup.yml
+++ b/jobs/ci-run/integration/gen/test-backup.yml
@@ -32,79 +32,10 @@
     - multijob:
         name: 'IntegrationTests-backup'
         projects:
-        - name: 'test-backup-test-basic-backup-lxd'
-          current-parameters: true
         - name: 'test-backup-test-basic-backup-aws'
           current-parameters: true
-
-- job:
-    name: test-backup-test-basic-backup-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test backup suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'backup'
-            setup_steps: ''
-            task_name: ''
-            skip_tasks: ''
-    publishers:
-      - integration-artifacts
+        - name: 'test-backup-test-basic-backup-lxd'
+          current-parameters: true
 
 - job:
     name: test-backup-test-basic-backup-aws
@@ -156,6 +87,75 @@
         default: 'us-east-1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'backup'
+            setup_steps: ''
+            task_name: ''
+            skip_tasks: ''
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-backup-test-basic-backup-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test backup suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-branches.yml
+++ b/jobs/ci-run/integration/gen/test-branches.yml
@@ -32,84 +32,14 @@
     - multijob:
         name: 'IntegrationTests-branches'
         projects:
-        - name: 'test-branches-test-active-branch-output-lxd'
-          current-parameters: true
         - name: 'test-branches-test-active-branch-output-aws'
           current-parameters: true
-        - name: 'test-branches-test-branch-lxd'
+        - name: 'test-branches-test-active-branch-output-lxd'
           current-parameters: true
         - name: 'test-branches-test-branch-aws'
           current-parameters: true
-
-- job:
-    name: test-branches-test-active-branch-output-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test test_active_branch_output in branches suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'branches'
-            setup_steps: ''
-            task_name: 'test_active_branch_output'
-            skip_tasks: 'test_branch'
-
-    publishers:
-      - integration-artifacts
+        - name: 'test-branches-test-branch-lxd'
+          current-parameters: true
 
 - job:
     name: test-branches-test-active-branch-output-aws
@@ -186,10 +116,10 @@
       - integration-artifacts
 
 - job:
-    name: test-branches-test-branch-lxd
+    name: test-branches-test-active-branch-output-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_branch in branches suite on lxd
+      Test test_active_branch_output in branches suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -249,8 +179,8 @@
       - run-integration-test:
             test_name: 'branches'
             setup_steps: ''
-            task_name: 'test_branch'
-            skip_tasks: 'test_active_branch_output'
+            task_name: 'test_active_branch_output'
+            skip_tasks: 'test_branch'
 
     publishers:
       - integration-artifacts
@@ -305,6 +235,76 @@
         default: 'us-east-1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'branches'
+            setup_steps: ''
+            task_name: 'test_branch'
+            skip_tasks: 'test_active_branch_output'
+
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-branches-test-branch-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test test_branch in branches suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-charmhub.yml
+++ b/jobs/ci-run/integration/gen/test-charmhub.yml
@@ -32,88 +32,18 @@
     - multijob:
         name: 'IntegrationTests-charmhub'
         projects:
-        - name: 'test-charmhub-test-charmhub-download-lxd'
-          current-parameters: true
         - name: 'test-charmhub-test-charmhub-download-aws'
           current-parameters: true
-        - name: 'test-charmhub-test-charmhub-find-lxd'
+        - name: 'test-charmhub-test-charmhub-download-lxd'
           current-parameters: true
         - name: 'test-charmhub-test-charmhub-find-aws'
           current-parameters: true
-        - name: 'test-charmhub-test-charmhub-info-lxd'
+        - name: 'test-charmhub-test-charmhub-find-lxd'
           current-parameters: true
         - name: 'test-charmhub-test-charmhub-info-aws'
           current-parameters: true
-
-- job:
-    name: test-charmhub-test-charmhub-download-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test test_charmhub_download in charmhub suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'charmhub'
-            setup_steps: ''
-            task_name: 'test_charmhub_download'
-            skip_tasks: 'test_charmhub_find,test_charmhub_info'
-
-    publishers:
-      - integration-artifacts
+        - name: 'test-charmhub-test-charmhub-info-lxd'
+          current-parameters: true
 
 - job:
     name: test-charmhub-test-charmhub-download-aws
@@ -190,10 +120,10 @@
       - integration-artifacts
 
 - job:
-    name: test-charmhub-test-charmhub-find-lxd
+    name: test-charmhub-test-charmhub-download-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_charmhub_find in charmhub suite on lxd
+      Test test_charmhub_download in charmhub suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -253,8 +183,8 @@
       - run-integration-test:
             test_name: 'charmhub'
             setup_steps: ''
-            task_name: 'test_charmhub_find'
-            skip_tasks: 'test_charmhub_download,test_charmhub_info'
+            task_name: 'test_charmhub_download'
+            skip_tasks: 'test_charmhub_find,test_charmhub_info'
 
     publishers:
       - integration-artifacts
@@ -334,10 +264,10 @@
       - integration-artifacts
 
 - job:
-    name: test-charmhub-test-charmhub-info-lxd
+    name: test-charmhub-test-charmhub-find-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_charmhub_info in charmhub suite on lxd
+      Test test_charmhub_find in charmhub suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -397,8 +327,8 @@
       - run-integration-test:
             test_name: 'charmhub'
             setup_steps: ''
-            task_name: 'test_charmhub_info'
-            skip_tasks: 'test_charmhub_download,test_charmhub_find'
+            task_name: 'test_charmhub_find'
+            skip_tasks: 'test_charmhub_download,test_charmhub_info'
 
     publishers:
       - integration-artifacts
@@ -453,6 +383,76 @@
         default: 'us-east-1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'charmhub'
+            setup_steps: ''
+            task_name: 'test_charmhub_info'
+            skip_tasks: 'test_charmhub_download,test_charmhub_find'
+
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-charmhub-test-charmhub-info-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test test_charmhub_info in charmhub suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-cmr.yml
+++ b/jobs/ci-run/integration/gen/test-cmr.yml
@@ -32,79 +32,10 @@
     - multijob:
         name: 'IntegrationTests-cmr'
         projects:
-        - name: 'test-cmr-test-offer-consume-lxd'
-          current-parameters: true
         - name: 'test-cmr-test-offer-consume-aws'
           current-parameters: true
-
-- job:
-    name: test-cmr-test-offer-consume-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test cmr suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'cmr'
-            setup_steps: ''
-            task_name: ''
-            skip_tasks: ''
-    publishers:
-      - integration-artifacts
+        - name: 'test-cmr-test-offer-consume-lxd'
+          current-parameters: true
 
 - job:
     name: test-cmr-test-offer-consume-aws
@@ -156,6 +87,75 @@
         default: 'us-east-1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'cmr'
+            setup_steps: ''
+            task_name: ''
+            skip_tasks: ''
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-cmr-test-offer-consume-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test cmr suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-constraints.yml
+++ b/jobs/ci-run/integration/gen/test-constraints.yml
@@ -32,79 +32,10 @@
     - multijob:
         name: 'IntegrationTests-constraints'
         projects:
-        - name: 'test-constraints-test-constraints-common-lxd'
-          current-parameters: true
         - name: 'test-constraints-test-constraints-common-google'
           current-parameters: true
-
-- job:
-    name: test-constraints-test-constraints-common-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test constraints suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'constraints'
-            setup_steps: ''
-            task_name: ''
-            skip_tasks: ''
-    publishers:
-      - integration-artifacts
+        - name: 'test-constraints-test-constraints-common-lxd'
+          current-parameters: true
 
 - job:
     name: test-constraints-test-constraints-common-google
@@ -156,6 +87,75 @@
         default: 'us-east1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'constraints'
+            setup_steps: ''
+            task_name: ''
+            skip_tasks: ''
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-constraints-test-constraints-common-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test constraints suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-controller.yml
+++ b/jobs/ci-run/integration/gen/test-controller.yml
@@ -32,84 +32,14 @@
     - multijob:
         name: 'IntegrationTests-controller'
         projects:
-        - name: 'test-controller-test-enable-ha-lxd'
-          current-parameters: true
         - name: 'test-controller-test-enable-ha-aws'
           current-parameters: true
-        - name: 'test-controller-test-mongo-memory-profile-lxd'
+        - name: 'test-controller-test-enable-ha-lxd'
           current-parameters: true
         - name: 'test-controller-test-mongo-memory-profile-aws'
           current-parameters: true
-
-- job:
-    name: test-controller-test-enable-ha-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test test_enable_ha in controller suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'controller'
-            setup_steps: ''
-            task_name: 'test_enable_ha'
-            skip_tasks: 'test_mongo_memory_profile'
-
-    publishers:
-      - integration-artifacts
+        - name: 'test-controller-test-mongo-memory-profile-lxd'
+          current-parameters: true
 
 - job:
     name: test-controller-test-enable-ha-aws
@@ -186,10 +116,10 @@
       - integration-artifacts
 
 - job:
-    name: test-controller-test-mongo-memory-profile-lxd
+    name: test-controller-test-enable-ha-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_mongo_memory_profile in controller suite on lxd
+      Test test_enable_ha in controller suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -249,8 +179,8 @@
       - run-integration-test:
             test_name: 'controller'
             setup_steps: ''
-            task_name: 'test_mongo_memory_profile'
-            skip_tasks: 'test_enable_ha'
+            task_name: 'test_enable_ha'
+            skip_tasks: 'test_mongo_memory_profile'
 
     publishers:
       - integration-artifacts
@@ -305,6 +235,76 @@
         default: 'us-east-1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'controller'
+            setup_steps: ''
+            task_name: 'test_mongo_memory_profile'
+            skip_tasks: 'test_enable_ha'
+
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-controller-test-mongo-memory-profile-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test test_mongo_memory_profile in controller suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-credential.yml
+++ b/jobs/ci-run/integration/gen/test-credential.yml
@@ -32,79 +32,10 @@
     - multijob:
         name: 'IntegrationTests-credential'
         projects:
-        - name: 'test-credential-test-add-remove-credential-lxd'
-          current-parameters: true
         - name: 'test-credential-test-add-remove-credential-aws'
           current-parameters: true
-
-- job:
-    name: test-credential-test-add-remove-credential-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test credential suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'credential'
-            setup_steps: ''
-            task_name: ''
-            skip_tasks: ''
-    publishers:
-      - integration-artifacts
+        - name: 'test-credential-test-add-remove-credential-lxd'
+          current-parameters: true
 
 - job:
     name: test-credential-test-add-remove-credential-aws
@@ -156,6 +87,75 @@
         default: 'us-east-1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'credential'
+            setup_steps: ''
+            task_name: ''
+            skip_tasks: ''
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-credential-test-add-remove-credential-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test credential suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-dashboard.yml
+++ b/jobs/ci-run/integration/gen/test-dashboard.yml
@@ -32,85 +32,16 @@
     - multijob:
         name: 'IntegrationTests-dashboard'
         projects:
-        - name: 'test-dashboard-test-dashboard-deploy-lxd'
-          current-parameters: true
         - name: 'test-dashboard-test-dashboard-deploy-aws'
-          current-parameters: true
-        - name: 'test-dashboard-test-dashboard-deploy-google'
           current-parameters: true
         - name: 'test-dashboard-test-dashboard-deploy-azure'
           current-parameters: true
+        - name: 'test-dashboard-test-dashboard-deploy-google'
+          current-parameters: true
+        - name: 'test-dashboard-test-dashboard-deploy-lxd'
+          current-parameters: true
         - name: 'test-dashboard-test-dashboard-deploy-microk8s'
           current-parameters: true
-
-- job:
-    name: test-dashboard-test-dashboard-deploy-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test dashboard suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'dashboard'
-            setup_steps: ''
-            task_name: ''
-            skip_tasks: ''
-    publishers:
-      - integration-artifacts
 
 - job:
     name: test-dashboard-test-dashboard-deploy-aws
@@ -160,6 +91,79 @@
         name: BOOTSTRAP_PROVIDER
     - string:
         default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'dashboard'
+            setup_steps: ''
+            task_name: ''
+            skip_tasks: ''
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-dashboard-test-dashboard-deploy-azure
+    node: ephemeral-focal-small-amd64
+    description: |-
+      Test dashboard suite on azure
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'azure'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'azure'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'centralus'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
     - string:
@@ -259,10 +263,10 @@
       - integration-artifacts
 
 - job:
-    name: test-dashboard-test-dashboard-deploy-azure
-    node: ephemeral-focal-small-amd64
+    name: test-dashboard-test-dashboard-deploy-lxd
+    node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test dashboard suite on azure
+      Test dashboard suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -297,17 +301,13 @@
         - s390x
         - ppc64el
     - string:
-        default: 'azure'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
-        default: 'azure'
+        default: 'lxd'
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
-    - string:
-        default: 'centralus'
-        description: 'Cloud Region to use when bootstrapping Juju'
-        name: BOOTSTRAP_REGION
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-deploy.yml
+++ b/jobs/ci-run/integration/gen/test-deploy.yml
@@ -32,92 +32,22 @@
     - multijob:
         name: 'IntegrationTests-deploy'
         projects:
-        - name: 'test-deploy-test-cmr-bundles-export-overlay-lxd'
-          current-parameters: true
         - name: 'test-deploy-test-cmr-bundles-export-overlay-aws'
+          current-parameters: true
+        - name: 'test-deploy-test-cmr-bundles-export-overlay-lxd'
           current-parameters: true
         - name: 'test-deploy-test-deploy-bundles-aws'
           current-parameters: true
         - name: 'test-deploy-test-deploy-charms-aws'
           current-parameters: true
-        - name: 'test-deploy-test-deploy-default-series-lxd'
-          current-parameters: true
         - name: 'test-deploy-test-deploy-default-series-aws'
+          current-parameters: true
+        - name: 'test-deploy-test-deploy-default-series-lxd'
           current-parameters: true
         - name: 'test-deploy-test-deploy-os-lxd'
           current-parameters: true
         - name: 'test-deploy-test-deploy-revision-lxd'
           current-parameters: true
-
-- job:
-    name: test-deploy-test-cmr-bundles-export-overlay-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test test_cmr_bundles_export_overlay in deploy suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'deploy'
-            setup_steps: ''
-            task_name: 'test_cmr_bundles_export_overlay'
-            skip_tasks: 'test_deploy_bundles,test_deploy_charms,test_deploy_default_series,test_deploy_os,test_deploy_revision'
-
-    publishers:
-      - integration-artifacts
 
 - job:
     name: test-deploy-test-cmr-bundles-export-overlay-aws
@@ -194,10 +124,10 @@
       - integration-artifacts
 
 - job:
-    name: test-deploy-test-deploy-bundles-lxd
+    name: test-deploy-test-cmr-bundles-export-overlay-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_deploy_bundles in deploy suite on lxd
+      Test test_cmr_bundles_export_overlay in deploy suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -250,15 +180,15 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
       - run-integration-test:
             test_name: 'deploy'
             setup_steps: ''
-            task_name: 'test_deploy_bundles'
-            skip_tasks: 'test_cmr_bundles_export_overlay,test_deploy_charms,test_deploy_default_series,test_deploy_os,test_deploy_revision'
+            task_name: 'test_cmr_bundles_export_overlay'
+            skip_tasks: 'test_deploy_bundles,test_deploy_charms,test_deploy_default_series,test_deploy_os,test_deploy_revision'
 
     publishers:
       - integration-artifacts
@@ -338,10 +268,10 @@
       - integration-artifacts
 
 - job:
-    name: test-deploy-test-deploy-charms-lxd
+    name: test-deploy-test-deploy-bundles-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_deploy_charms in deploy suite on lxd
+      Test test_deploy_bundles in deploy suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -394,15 +324,15 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
       - run-integration-test:
             test_name: 'deploy'
             setup_steps: ''
-            task_name: 'test_deploy_charms'
-            skip_tasks: 'test_cmr_bundles_export_overlay,test_deploy_bundles,test_deploy_default_series,test_deploy_os,test_deploy_revision'
+            task_name: 'test_deploy_bundles'
+            skip_tasks: 'test_cmr_bundles_export_overlay,test_deploy_charms,test_deploy_default_series,test_deploy_os,test_deploy_revision'
 
     publishers:
       - integration-artifacts
@@ -482,10 +412,10 @@
       - integration-artifacts
 
 - job:
-    name: test-deploy-test-deploy-default-series-lxd
+    name: test-deploy-test-deploy-charms-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_deploy_default_series in deploy suite on lxd
+      Test test_deploy_charms in deploy suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -545,8 +475,8 @@
       - run-integration-test:
             test_name: 'deploy'
             setup_steps: ''
-            task_name: 'test_deploy_default_series'
-            skip_tasks: 'test_cmr_bundles_export_overlay,test_deploy_bundles,test_deploy_charms,test_deploy_os,test_deploy_revision'
+            task_name: 'test_deploy_charms'
+            skip_tasks: 'test_cmr_bundles_export_overlay,test_deploy_bundles,test_deploy_default_series,test_deploy_os,test_deploy_revision'
 
     publishers:
       - integration-artifacts
@@ -626,10 +556,10 @@
       - integration-artifacts
 
 - job:
-    name: test-deploy-test-deploy-os-lxd
+    name: test-deploy-test-deploy-default-series-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_deploy_os in deploy suite on lxd
+      Test test_deploy_default_series in deploy suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -689,8 +619,8 @@
       - run-integration-test:
             test_name: 'deploy'
             setup_steps: ''
-            task_name: 'test_deploy_os'
-            skip_tasks: 'test_cmr_bundles_export_overlay,test_deploy_bundles,test_deploy_charms,test_deploy_default_series,test_deploy_revision'
+            task_name: 'test_deploy_default_series'
+            skip_tasks: 'test_cmr_bundles_export_overlay,test_deploy_bundles,test_deploy_charms,test_deploy_os,test_deploy_revision'
 
     publishers:
       - integration-artifacts
@@ -770,10 +700,10 @@
       - integration-artifacts
 
 - job:
-    name: test-deploy-test-deploy-revision-lxd
+    name: test-deploy-test-deploy-os-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_deploy_revision in deploy suite on lxd
+      Test test_deploy_os in deploy suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -833,8 +763,8 @@
       - run-integration-test:
             test_name: 'deploy'
             setup_steps: ''
-            task_name: 'test_deploy_revision'
-            skip_tasks: 'test_cmr_bundles_export_overlay,test_deploy_bundles,test_deploy_charms,test_deploy_default_series,test_deploy_os'
+            task_name: 'test_deploy_os'
+            skip_tasks: 'test_cmr_bundles_export_overlay,test_deploy_bundles,test_deploy_charms,test_deploy_default_series,test_deploy_revision'
 
     publishers:
       - integration-artifacts
@@ -889,6 +819,76 @@
         default: 'us-east-1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'deploy'
+            setup_steps: ''
+            task_name: 'test_deploy_revision'
+            skip_tasks: 'test_cmr_bundles_export_overlay,test_deploy_bundles,test_deploy_charms,test_deploy_default_series,test_deploy_os'
+
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-deploy-test-deploy-revision-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test test_deploy_revision in deploy suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-hooks.yml
+++ b/jobs/ci-run/integration/gen/test-hooks.yml
@@ -32,84 +32,14 @@
     - multijob:
         name: 'IntegrationTests-hooks'
         projects:
-        - name: 'test-hooks-test-dispatching-script-lxd'
-          current-parameters: true
         - name: 'test-hooks-test-dispatching-script-aws'
           current-parameters: true
-        - name: 'test-hooks-test-start-hook-fires-after-reboot-lxd'
+        - name: 'test-hooks-test-dispatching-script-lxd'
           current-parameters: true
         - name: 'test-hooks-test-start-hook-fires-after-reboot-aws'
           current-parameters: true
-
-- job:
-    name: test-hooks-test-dispatching-script-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test test_dispatching_script in hooks suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'hooks'
-            setup_steps: ''
-            task_name: 'test_dispatching_script'
-            skip_tasks: 'test_start_hook_fires_after_reboot'
-
-    publishers:
-      - integration-artifacts
+        - name: 'test-hooks-test-start-hook-fires-after-reboot-lxd'
+          current-parameters: true
 
 - job:
     name: test-hooks-test-dispatching-script-aws
@@ -186,10 +116,10 @@
       - integration-artifacts
 
 - job:
-    name: test-hooks-test-start-hook-fires-after-reboot-lxd
+    name: test-hooks-test-dispatching-script-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_start_hook_fires_after_reboot in hooks suite on lxd
+      Test test_dispatching_script in hooks suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -249,8 +179,8 @@
       - run-integration-test:
             test_name: 'hooks'
             setup_steps: ''
-            task_name: 'test_start_hook_fires_after_reboot'
-            skip_tasks: 'test_dispatching_script'
+            task_name: 'test_dispatching_script'
+            skip_tasks: 'test_start_hook_fires_after_reboot'
 
     publishers:
       - integration-artifacts
@@ -305,6 +235,76 @@
         default: 'us-east-1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'hooks'
+            setup_steps: ''
+            task_name: 'test_start_hook_fires_after_reboot'
+            skip_tasks: 'test_dispatching_script'
+
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-hooks-test-start-hook-fires-after-reboot-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test test_start_hook_fires_after_reboot in hooks suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-hooktools.yml
+++ b/jobs/ci-run/integration/gen/test-hooktools.yml
@@ -32,79 +32,10 @@
     - multijob:
         name: 'IntegrationTests-hooktools'
         projects:
-        - name: 'test-hooktools-test-state-hook-tools-lxd'
-          current-parameters: true
         - name: 'test-hooktools-test-state-hook-tools-aws'
           current-parameters: true
-
-- job:
-    name: test-hooktools-test-state-hook-tools-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test hooktools suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'hooktools'
-            setup_steps: ''
-            task_name: ''
-            skip_tasks: ''
-    publishers:
-      - integration-artifacts
+        - name: 'test-hooktools-test-state-hook-tools-lxd'
+          current-parameters: true
 
 - job:
     name: test-hooktools-test-state-hook-tools-aws
@@ -156,6 +87,75 @@
         default: 'us-east-1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'hooktools'
+            setup_steps: ''
+            task_name: ''
+            skip_tasks: ''
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-hooktools-test-state-hook-tools-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test hooktools suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-machine.yml
+++ b/jobs/ci-run/integration/gen/test-machine.yml
@@ -32,79 +32,10 @@
     - multijob:
         name: 'IntegrationTests-machine'
         projects:
-        - name: 'test-machine-test-logs-lxd'
-          current-parameters: true
         - name: 'test-machine-test-logs-aws'
           current-parameters: true
-
-- job:
-    name: test-machine-test-logs-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test machine suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'machine'
-            setup_steps: ''
-            task_name: ''
-            skip_tasks: ''
-    publishers:
-      - integration-artifacts
+        - name: 'test-machine-test-logs-lxd'
+          current-parameters: true
 
 - job:
     name: test-machine-test-logs-aws
@@ -156,6 +87,75 @@
         default: 'us-east-1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'machine'
+            setup_steps: ''
+            task_name: ''
+            skip_tasks: ''
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-machine-test-logs-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test machine suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-manual.yml
+++ b/jobs/ci-run/integration/gen/test-manual.yml
@@ -32,84 +32,14 @@
     - multijob:
         name: 'IntegrationTests-manual'
         projects:
-        - name: 'test-manual-test-deploy-manual-lxd'
-          current-parameters: true
         - name: 'test-manual-test-deploy-manual-aws'
           current-parameters: true
-        - name: 'test-manual-test-spaces-manual-lxd'
+        - name: 'test-manual-test-deploy-manual-lxd'
           current-parameters: true
         - name: 'test-manual-test-spaces-manual-aws'
           current-parameters: true
-
-- job:
-    name: test-manual-test-deploy-manual-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test test_deploy_manual in manual suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'manual'
-            setup_steps: ''
-            task_name: 'test_deploy_manual'
-            skip_tasks: 'test_spaces_manual'
-
-    publishers:
-      - integration-artifacts
+        - name: 'test-manual-test-spaces-manual-lxd'
+          current-parameters: true
 
 - job:
     name: test-manual-test-deploy-manual-aws
@@ -186,10 +116,10 @@
       - integration-artifacts
 
 - job:
-    name: test-manual-test-spaces-manual-lxd
+    name: test-manual-test-deploy-manual-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_spaces_manual in manual suite on lxd
+      Test test_deploy_manual in manual suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -249,8 +179,8 @@
       - run-integration-test:
             test_name: 'manual'
             setup_steps: ''
-            task_name: 'test_spaces_manual'
-            skip_tasks: 'test_deploy_manual'
+            task_name: 'test_deploy_manual'
+            skip_tasks: 'test_spaces_manual'
 
     publishers:
       - integration-artifacts
@@ -305,6 +235,76 @@
         default: 'us-east-1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'manual'
+            setup_steps: ''
+            task_name: 'test_spaces_manual'
+            skip_tasks: 'test_deploy_manual'
+
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-manual-test-spaces-manual-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test test_spaces_manual in manual suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-model-unstable.yml
+++ b/jobs/ci-run/integration/gen/test-model-unstable.yml
@@ -32,21 +32,21 @@
     - multijob:
         name: 'IntegrationTests-model'
         projects:
-        - name: 'test-model-test-model-config-lxd'
-          current-parameters: true
         - name: 'test-model-test-model-config-aws'
           current-parameters: true
         - name: 'test-model-test-model-config-google'
           current-parameters: true
-        - name: 'test-model-test-model-metrics-lxd'
+        - name: 'test-model-test-model-config-lxd'
           current-parameters: true
         - name: 'test-model-test-model-metrics-aws'
           current-parameters: true
         - name: 'test-model-test-model-metrics-google'
           current-parameters: true
-        - name: 'test-model-test-model-multi-lxd'
+        - name: 'test-model-test-model-metrics-lxd'
           current-parameters: true
         - name: 'test-model-test-model-multi-aws'
           current-parameters: true
         - name: 'test-model-test-model-multi-google'
+          current-parameters: true
+        - name: 'test-model-test-model-multi-lxd'
           current-parameters: true

--- a/jobs/ci-run/integration/gen/test-model.yml
+++ b/jobs/ci-run/integration/gen/test-model.yml
@@ -32,112 +32,42 @@
     - multijob:
         name: 'IntegrationTests-model'
         projects:
-        - name: 'test-model-test-model-destroy-lxd'
-          current-parameters: true
         - name: 'test-model-test-model-destroy-aws'
           current-parameters: true
         - name: 'test-model-test-model-destroy-google'
           current-parameters: true
-        - name: 'test-model-test-model-migration-lxd'
+        - name: 'test-model-test-model-destroy-lxd'
           current-parameters: true
         - name: 'test-model-test-model-migration-aws'
           current-parameters: true
         - name: 'test-model-test-model-migration-google'
           current-parameters: true
-        - name: 'test-model-test-model-migration-saas-common-lxd'
+        - name: 'test-model-test-model-migration-lxd'
           current-parameters: true
         - name: 'test-model-test-model-migration-saas-common-aws'
           current-parameters: true
         - name: 'test-model-test-model-migration-saas-common-google'
           current-parameters: true
-        - name: 'test-model-test-model-migration-saas-external-lxd'
+        - name: 'test-model-test-model-migration-saas-common-lxd'
           current-parameters: true
         - name: 'test-model-test-model-migration-saas-external-aws'
           current-parameters: true
         - name: 'test-model-test-model-migration-saas-external-google'
           current-parameters: true
-        - name: 'test-model-test-model-migration-version-lxd'
+        - name: 'test-model-test-model-migration-saas-external-lxd'
           current-parameters: true
         - name: 'test-model-test-model-migration-version-aws'
           current-parameters: true
         - name: 'test-model-test-model-migration-version-google'
           current-parameters: true
-        - name: 'test-model-test-model-status-lxd'
+        - name: 'test-model-test-model-migration-version-lxd'
           current-parameters: true
         - name: 'test-model-test-model-status-aws'
           current-parameters: true
         - name: 'test-model-test-model-status-google'
           current-parameters: true
-
-- job:
-    name: test-model-test-model-config-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test test_model_config in model suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'model'
-            setup_steps: ''
-            task_name: 'test_model_config'
-            skip_tasks: 'test_model_destroy,test_model_metrics,test_model_migration,test_model_migration_saas_common,test_model_migration_saas_external,test_model_migration_version,test_model_multi,test_model_status'
-
-    publishers:
-      - integration-artifacts
+        - name: 'test-model-test-model-status-lxd'
+          current-parameters: true
 
 - job:
     name: test-model-test-model-config-aws
@@ -288,10 +218,10 @@
       - integration-artifacts
 
 - job:
-    name: test-model-test-model-destroy-lxd
+    name: test-model-test-model-config-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_model_destroy in model suite on lxd
+      Test test_model_config in model suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -351,8 +281,8 @@
       - run-integration-test:
             test_name: 'model'
             setup_steps: ''
-            task_name: 'test_model_destroy'
-            skip_tasks: 'test_model_config,test_model_metrics,test_model_migration,test_model_migration_saas_common,test_model_migration_saas_external,test_model_migration_version,test_model_multi,test_model_status'
+            task_name: 'test_model_config'
+            skip_tasks: 'test_model_destroy,test_model_metrics,test_model_migration,test_model_migration_saas_common,test_model_migration_saas_external,test_model_migration_version,test_model_multi,test_model_status'
 
     publishers:
       - integration-artifacts
@@ -506,10 +436,10 @@
       - integration-artifacts
 
 - job:
-    name: test-model-test-model-metrics-lxd
+    name: test-model-test-model-destroy-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_model_metrics in model suite on lxd
+      Test test_model_destroy in model suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -569,8 +499,8 @@
       - run-integration-test:
             test_name: 'model'
             setup_steps: ''
-            task_name: 'test_model_metrics'
-            skip_tasks: 'test_model_config,test_model_destroy,test_model_migration,test_model_migration_saas_common,test_model_migration_saas_external,test_model_migration_version,test_model_multi,test_model_status'
+            task_name: 'test_model_destroy'
+            skip_tasks: 'test_model_config,test_model_metrics,test_model_migration,test_model_migration_saas_common,test_model_migration_saas_external,test_model_migration_version,test_model_multi,test_model_status'
 
     publishers:
       - integration-artifacts
@@ -724,10 +654,10 @@
       - integration-artifacts
 
 - job:
-    name: test-model-test-model-migration-lxd
+    name: test-model-test-model-metrics-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_model_migration in model suite on lxd
+      Test test_model_metrics in model suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -780,15 +710,15 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 90
+          timeout: 30
           fail: true
           type: absolute
     builders:
       - run-integration-test:
             test_name: 'model'
             setup_steps: ''
-            task_name: 'test_model_migration'
-            skip_tasks: 'test_model_config,test_model_destroy,test_model_metrics,test_model_migration_saas_common,test_model_migration_saas_external,test_model_migration_version,test_model_multi,test_model_status'
+            task_name: 'test_model_metrics'
+            skip_tasks: 'test_model_config,test_model_destroy,test_model_migration,test_model_migration_saas_common,test_model_migration_saas_external,test_model_migration_version,test_model_multi,test_model_status'
 
     publishers:
       - integration-artifacts
@@ -942,10 +872,10 @@
       - integration-artifacts
 
 - job:
-    name: test-model-test-model-migration-saas-common-lxd
+    name: test-model-test-model-migration-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_model_migration_saas_common in model suite on lxd
+      Test test_model_migration in model suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -998,15 +928,15 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 90
           fail: true
           type: absolute
     builders:
       - run-integration-test:
             test_name: 'model'
             setup_steps: ''
-            task_name: 'test_model_migration_saas_common'
-            skip_tasks: 'test_model_config,test_model_destroy,test_model_metrics,test_model_migration,test_model_migration_saas_external,test_model_migration_version,test_model_multi,test_model_status'
+            task_name: 'test_model_migration'
+            skip_tasks: 'test_model_config,test_model_destroy,test_model_metrics,test_model_migration_saas_common,test_model_migration_saas_external,test_model_migration_version,test_model_multi,test_model_status'
 
     publishers:
       - integration-artifacts
@@ -1160,10 +1090,10 @@
       - integration-artifacts
 
 - job:
-    name: test-model-test-model-migration-saas-external-lxd
+    name: test-model-test-model-migration-saas-common-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_model_migration_saas_external in model suite on lxd
+      Test test_model_migration_saas_common in model suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -1223,8 +1153,8 @@
       - run-integration-test:
             test_name: 'model'
             setup_steps: ''
-            task_name: 'test_model_migration_saas_external'
-            skip_tasks: 'test_model_config,test_model_destroy,test_model_metrics,test_model_migration,test_model_migration_saas_common,test_model_migration_version,test_model_multi,test_model_status'
+            task_name: 'test_model_migration_saas_common'
+            skip_tasks: 'test_model_config,test_model_destroy,test_model_metrics,test_model_migration,test_model_migration_saas_external,test_model_migration_version,test_model_multi,test_model_status'
 
     publishers:
       - integration-artifacts
@@ -1378,10 +1308,10 @@
       - integration-artifacts
 
 - job:
-    name: test-model-test-model-migration-version-lxd
+    name: test-model-test-model-migration-saas-external-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_model_migration_version in model suite on lxd
+      Test test_model_migration_saas_external in model suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -1434,15 +1364,15 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 50
+          timeout: 30
           fail: true
           type: absolute
     builders:
       - run-integration-test:
             test_name: 'model'
             setup_steps: ''
-            task_name: 'test_model_migration_version'
-            skip_tasks: 'test_model_config,test_model_destroy,test_model_metrics,test_model_migration,test_model_migration_saas_common,test_model_migration_saas_external,test_model_multi,test_model_status'
+            task_name: 'test_model_migration_saas_external'
+            skip_tasks: 'test_model_config,test_model_destroy,test_model_metrics,test_model_migration,test_model_migration_saas_common,test_model_migration_version,test_model_multi,test_model_status'
 
     publishers:
       - integration-artifacts
@@ -1596,10 +1526,10 @@
       - integration-artifacts
 
 - job:
-    name: test-model-test-model-multi-lxd
+    name: test-model-test-model-migration-version-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_model_multi in model suite on lxd
+      Test test_model_migration_version in model suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -1652,15 +1582,15 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
       - run-integration-test:
             test_name: 'model'
             setup_steps: ''
-            task_name: 'test_model_multi'
-            skip_tasks: 'test_model_config,test_model_destroy,test_model_metrics,test_model_migration,test_model_migration_saas_common,test_model_migration_saas_external,test_model_migration_version,test_model_status'
+            task_name: 'test_model_migration_version'
+            skip_tasks: 'test_model_config,test_model_destroy,test_model_metrics,test_model_migration,test_model_migration_saas_common,test_model_migration_saas_external,test_model_multi,test_model_status'
 
     publishers:
       - integration-artifacts
@@ -1814,10 +1744,10 @@
       - integration-artifacts
 
 - job:
-    name: test-model-test-model-status-lxd
+    name: test-model-test-model-multi-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_model_status in model suite on lxd
+      Test test_model_multi in model suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -1877,8 +1807,8 @@
       - run-integration-test:
             test_name: 'model'
             setup_steps: ''
-            task_name: 'test_model_status'
-            skip_tasks: 'test_model_config,test_model_destroy,test_model_metrics,test_model_migration,test_model_migration_saas_common,test_model_migration_saas_external,test_model_migration_version,test_model_multi'
+            task_name: 'test_model_multi'
+            skip_tasks: 'test_model_config,test_model_destroy,test_model_metrics,test_model_migration,test_model_migration_saas_common,test_model_migration_saas_external,test_model_migration_version,test_model_status'
 
     publishers:
       - integration-artifacts
@@ -2007,6 +1937,76 @@
         default: 'us-east1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'model'
+            setup_steps: ''
+            task_name: 'test_model_status'
+            skip_tasks: 'test_model_config,test_model_destroy,test_model_metrics,test_model_migration,test_model_migration_saas_common,test_model_migration_saas_external,test_model_migration_version,test_model_multi'
+
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-model-test-model-status-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test test_model_status in model suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-network.yml
+++ b/jobs/ci-run/integration/gen/test-network.yml
@@ -32,83 +32,14 @@
     - multijob:
         name: 'IntegrationTests-network'
         projects:
-        - name: 'test-network-test-network-health-lxd'
-          current-parameters: true
         - name: 'test-network-test-network-health-aws'
-          current-parameters: true
-        - name: 'test-network-test-network-health-google'
           current-parameters: true
         - name: 'test-network-test-network-health-azure'
           current-parameters: true
-
-- job:
-    name: test-network-test-network-health-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test network suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'network'
-            setup_steps: ''
-            task_name: ''
-            skip_tasks: ''
-    publishers:
-      - integration-artifacts
+        - name: 'test-network-test-network-health-google'
+          current-parameters: true
+        - name: 'test-network-test-network-health-lxd'
+          current-parameters: true
 
 - job:
     name: test-network-test-network-health-aws
@@ -158,6 +89,79 @@
         name: BOOTSTRAP_PROVIDER
     - string:
         default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'network'
+            setup_steps: ''
+            task_name: ''
+            skip_tasks: ''
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-network-test-network-health-azure
+    node: ephemeral-focal-small-amd64
+    description: |-
+      Test network suite on azure
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'azure'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'azure'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'centralus'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
     - string:
@@ -257,10 +261,10 @@
       - integration-artifacts
 
 - job:
-    name: test-network-test-network-health-azure
-    node: ephemeral-focal-small-amd64
+    name: test-network-test-network-health-lxd
+    node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test network suite on azure
+      Test network suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -295,17 +299,13 @@
         - s390x
         - ppc64el
     - string:
-        default: 'azure'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
-        default: 'azure'
+        default: 'lxd'
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
-    - string:
-        default: 'centralus'
-        description: 'Cloud Region to use when bootstrapping Juju'
-        name: BOOTSTRAP_REGION
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-refresh.yml
+++ b/jobs/ci-run/integration/gen/test-refresh.yml
@@ -32,96 +32,26 @@
     - multijob:
         name: 'IntegrationTests-refresh'
         projects:
-        - name: 'test-refresh-test-basic-lxd'
-          current-parameters: true
         - name: 'test-refresh-test-basic-aws'
-          current-parameters: true
-        - name: 'test-refresh-test-basic-google'
           current-parameters: true
         - name: 'test-refresh-test-basic-azure'
           current-parameters: true
-        - name: 'test-refresh-test-basic-microk8s'
+        - name: 'test-refresh-test-basic-google'
           current-parameters: true
-        - name: 'test-refresh-test-switch-lxd'
+        - name: 'test-refresh-test-basic-lxd'
+          current-parameters: true
+        - name: 'test-refresh-test-basic-microk8s'
           current-parameters: true
         - name: 'test-refresh-test-switch-aws'
           current-parameters: true
+        - name: 'test-refresh-test-switch-azure'
+          current-parameters: true
         - name: 'test-refresh-test-switch-google'
           current-parameters: true
-        - name: 'test-refresh-test-switch-azure'
+        - name: 'test-refresh-test-switch-lxd'
           current-parameters: true
         - name: 'test-refresh-test-switch-microk8s'
           current-parameters: true
-
-- job:
-    name: test-refresh-test-basic-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test test_basic in refresh suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'refresh'
-            setup_steps: ''
-            task_name: 'test_basic'
-            skip_tasks: 'test_switch'
-
-    publishers:
-      - integration-artifacts
 
 - job:
     name: test-refresh-test-basic-aws
@@ -171,80 +101,6 @@
         name: BOOTSTRAP_PROVIDER
     - string:
         default: 'us-east-1'
-        description: 'Cloud Region to use when bootstrapping Juju'
-        name: BOOTSTRAP_REGION
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'refresh'
-            setup_steps: ''
-            task_name: 'test_basic'
-            skip_tasks: 'test_switch'
-
-    publishers:
-      - integration-artifacts
-
-- job:
-    name: test-refresh-test-basic-google
-    node: ephemeral-focal-small-amd64
-    description: |-
-      Test test_basic in refresh suite on google
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'google'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'google'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: 'us-east1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
     - string:
@@ -346,6 +202,150 @@
       - integration-artifacts
 
 - job:
+    name: test-refresh-test-basic-google
+    node: ephemeral-focal-small-amd64
+    description: |-
+      Test test_basic in refresh suite on google
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'google'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'google'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'refresh'
+            setup_steps: ''
+            task_name: 'test_basic'
+            skip_tasks: 'test_switch'
+
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-refresh-test-basic-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test test_basic in refresh suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'refresh'
+            setup_steps: ''
+            task_name: 'test_basic'
+            skip_tasks: 'test_switch'
+
+    publishers:
+      - integration-artifacts
+
+- job:
     name: test-refresh-test-basic-microk8s
     node: ephemeral-focal-8c-32g-amd64
     description: |-
@@ -416,76 +416,6 @@
       - integration-artifacts
 
 - job:
-    name: test-refresh-test-switch-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test test_switch in refresh suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'refresh'
-            setup_steps: ''
-            task_name: 'test_switch'
-            skip_tasks: 'test_basic'
-
-    publishers:
-      - integration-artifacts
-
-- job:
     name: test-refresh-test-switch-aws
     node: ephemeral-focal-small-amd64
     description: |-
@@ -533,6 +463,80 @@
         name: BOOTSTRAP_PROVIDER
     - string:
         default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'refresh'
+            setup_steps: ''
+            task_name: 'test_switch'
+            skip_tasks: 'test_basic'
+
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-refresh-test-switch-azure
+    node: ephemeral-focal-small-amd64
+    description: |-
+      Test test_switch in refresh suite on azure
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'azure'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'azure'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'centralus'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
     - string:
@@ -634,10 +638,10 @@
       - integration-artifacts
 
 - job:
-    name: test-refresh-test-switch-azure
-    node: ephemeral-focal-small-amd64
+    name: test-refresh-test-switch-lxd
+    node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_switch in refresh suite on azure
+      Test test_switch in refresh suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -672,17 +676,13 @@
         - s390x
         - ppc64el
     - string:
-        default: 'azure'
+        default: 'lxd'
         description: 'Cloud to use when bootstrapping Juju'
         name: BOOTSTRAP_CLOUD
     - string:
-        default: 'azure'
+        default: 'lxd'
         description: 'Provider to use when bootstrapping Juju'
         name: BOOTSTRAP_PROVIDER
-    - string:
-        default: 'centralus'
-        description: 'Cloud Region to use when bootstrapping Juju'
-        name: BOOTSTRAP_REGION
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-relations.yml
+++ b/jobs/ci-run/integration/gen/test-relations.yml
@@ -32,88 +32,18 @@
     - multijob:
         name: 'IntegrationTests-relations'
         projects:
-        - name: 'test-relations-test-relation-data-exchange-lxd'
-          current-parameters: true
         - name: 'test-relations-test-relation-data-exchange-aws'
           current-parameters: true
-        - name: 'test-relations-test-relation-departing-unit-lxd'
+        - name: 'test-relations-test-relation-data-exchange-lxd'
           current-parameters: true
         - name: 'test-relations-test-relation-departing-unit-aws'
           current-parameters: true
-        - name: 'test-relations-test-relation-list-app-lxd'
+        - name: 'test-relations-test-relation-departing-unit-lxd'
           current-parameters: true
         - name: 'test-relations-test-relation-list-app-aws'
           current-parameters: true
-
-- job:
-    name: test-relations-test-relation-data-exchange-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test test_relation_data_exchange in relations suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'relations'
-            setup_steps: ''
-            task_name: 'test_relation_data_exchange'
-            skip_tasks: 'test_relation_departing_unit,test_relation_list_app'
-
-    publishers:
-      - integration-artifacts
+        - name: 'test-relations-test-relation-list-app-lxd'
+          current-parameters: true
 
 - job:
     name: test-relations-test-relation-data-exchange-aws
@@ -190,10 +120,10 @@
       - integration-artifacts
 
 - job:
-    name: test-relations-test-relation-departing-unit-lxd
+    name: test-relations-test-relation-data-exchange-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_relation_departing_unit in relations suite on lxd
+      Test test_relation_data_exchange in relations suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -253,8 +183,8 @@
       - run-integration-test:
             test_name: 'relations'
             setup_steps: ''
-            task_name: 'test_relation_departing_unit'
-            skip_tasks: 'test_relation_data_exchange,test_relation_list_app'
+            task_name: 'test_relation_data_exchange'
+            skip_tasks: 'test_relation_departing_unit,test_relation_list_app'
 
     publishers:
       - integration-artifacts
@@ -334,10 +264,10 @@
       - integration-artifacts
 
 - job:
-    name: test-relations-test-relation-list-app-lxd
+    name: test-relations-test-relation-departing-unit-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_relation_list_app in relations suite on lxd
+      Test test_relation_departing_unit in relations suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -397,8 +327,8 @@
       - run-integration-test:
             test_name: 'relations'
             setup_steps: ''
-            task_name: 'test_relation_list_app'
-            skip_tasks: 'test_relation_data_exchange,test_relation_departing_unit'
+            task_name: 'test_relation_departing_unit'
+            skip_tasks: 'test_relation_data_exchange,test_relation_list_app'
 
     publishers:
       - integration-artifacts
@@ -453,6 +383,76 @@
         default: 'us-east-1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'relations'
+            setup_steps: ''
+            task_name: 'test_relation_list_app'
+            skip_tasks: 'test_relation_data_exchange,test_relation_departing_unit'
+
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-relations-test-relation-list-app-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test test_relation_list_app in relations suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-resources.yml
+++ b/jobs/ci-run/integration/gen/test-resources.yml
@@ -32,84 +32,14 @@
     - multijob:
         name: 'IntegrationTests-resources'
         projects:
-        - name: 'test-resources-test-basic-resources-lxd'
-          current-parameters: true
         - name: 'test-resources-test-basic-resources-aws'
           current-parameters: true
-        - name: 'test-resources-test-upgrade-resources-lxd'
+        - name: 'test-resources-test-basic-resources-lxd'
           current-parameters: true
         - name: 'test-resources-test-upgrade-resources-aws'
           current-parameters: true
-
-- job:
-    name: test-resources-test-basic-resources-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test test_basic_resources in resources suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'resources'
-            setup_steps: ''
-            task_name: 'test_basic_resources'
-            skip_tasks: 'test_upgrade_resources'
-
-    publishers:
-      - integration-artifacts
+        - name: 'test-resources-test-upgrade-resources-lxd'
+          current-parameters: true
 
 - job:
     name: test-resources-test-basic-resources-aws
@@ -186,10 +116,10 @@
       - integration-artifacts
 
 - job:
-    name: test-resources-test-upgrade-resources-lxd
+    name: test-resources-test-basic-resources-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_upgrade_resources in resources suite on lxd
+      Test test_basic_resources in resources suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -249,8 +179,8 @@
       - run-integration-test:
             test_name: 'resources'
             setup_steps: ''
-            task_name: 'test_upgrade_resources'
-            skip_tasks: 'test_basic_resources'
+            task_name: 'test_basic_resources'
+            skip_tasks: 'test_upgrade_resources'
 
     publishers:
       - integration-artifacts
@@ -305,6 +235,76 @@
         default: 'us-east-1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'resources'
+            setup_steps: ''
+            task_name: 'test_upgrade_resources'
+            skip_tasks: 'test_basic_resources'
+
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-resources-test-upgrade-resources-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test test_upgrade_resources in resources suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-smoke.yml
+++ b/jobs/ci-run/integration/gen/test-smoke.yml
@@ -32,84 +32,14 @@
     - multijob:
         name: 'IntegrationTests-smoke'
         projects:
-        - name: 'test-smoke-test-build-lxd'
-          current-parameters: true
         - name: 'test-smoke-test-build-aws'
           current-parameters: true
-        - name: 'test-smoke-test-deploy-lxd'
+        - name: 'test-smoke-test-build-lxd'
           current-parameters: true
         - name: 'test-smoke-test-deploy-aws'
           current-parameters: true
-
-- job:
-    name: test-smoke-test-build-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test test_build in smoke suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'smoke'
-            setup_steps: ''
-            task_name: 'test_build'
-            skip_tasks: 'test_deploy'
-
-    publishers:
-      - integration-artifacts
+        - name: 'test-smoke-test-deploy-lxd'
+          current-parameters: true
 
 - job:
     name: test-smoke-test-build-aws
@@ -186,10 +116,10 @@
       - integration-artifacts
 
 - job:
-    name: test-smoke-test-deploy-lxd
+    name: test-smoke-test-build-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_deploy in smoke suite on lxd
+      Test test_build in smoke suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -249,8 +179,8 @@
       - run-integration-test:
             test_name: 'smoke'
             setup_steps: ''
-            task_name: 'test_deploy'
-            skip_tasks: 'test_build'
+            task_name: 'test_build'
+            skip_tasks: 'test_deploy'
 
     publishers:
       - integration-artifacts
@@ -305,6 +235,76 @@
         default: 'us-east-1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'smoke'
+            setup_steps: ''
+            task_name: 'test_deploy'
+            skip_tasks: 'test_build'
+
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-smoke-test-deploy-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test test_deploy in smoke suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-unit.yml
+++ b/jobs/ci-run/integration/gen/test-unit.yml
@@ -32,79 +32,10 @@
     - multijob:
         name: 'IntegrationTests-unit'
         projects:
-        - name: 'test-unit-test-unit-series-lxd'
-          current-parameters: true
         - name: 'test-unit-test-unit-series-aws'
           current-parameters: true
-
-- job:
-    name: test-unit-test-unit-series-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test unit suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'unit'
-            setup_steps: ''
-            task_name: ''
-            skip_tasks: ''
-    publishers:
-      - integration-artifacts
+        - name: 'test-unit-test-unit-series-lxd'
+          current-parameters: true
 
 - job:
     name: test-unit-test-unit-series-aws
@@ -156,6 +87,75 @@
         default: 'us-east-1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'unit'
+            setup_steps: ''
+            task_name: ''
+            skip_tasks: ''
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-unit-test-unit-series-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test unit suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/integration/gen/test-user-unstable.yml
+++ b/jobs/ci-run/integration/gen/test-user-unstable.yml
@@ -32,7 +32,7 @@
     - multijob:
         name: 'IntegrationTests-user'
         projects:
-        - name: 'test-user-test-user-login-password-lxd'
-          current-parameters: true
         - name: 'test-user-test-user-login-password-aws'
+          current-parameters: true
+        - name: 'test-user-test-user-login-password-lxd'
           current-parameters: true

--- a/jobs/ci-run/integration/gen/test-user.yml
+++ b/jobs/ci-run/integration/gen/test-user.yml
@@ -32,80 +32,10 @@
     - multijob:
         name: 'IntegrationTests-user'
         projects:
-        - name: 'test-user-test-user-manage-lxd'
-          current-parameters: true
         - name: 'test-user-test-user-manage-aws'
           current-parameters: true
-
-- job:
-    name: test-user-test-user-login-password-lxd
-    node: ephemeral-focal-8c-32g-amd64
-    description: |-
-      Test test_user_login_password in user suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{7}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'lxd'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: ''
-        description: 'Ubuntu series to use when bootstrapping Juju'
-        name: BOOTSTRAP_SERIES
-    - string:
-        default: jujuqabot
-        description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - run-integration-test:
-            test_name: 'user'
-            setup_steps: ''
-            task_name: 'test_user_login_password'
-            skip_tasks: 'test_user_manage'
-
-    publishers:
-      - integration-artifacts
+        - name: 'test-user-test-user-manage-lxd'
+          current-parameters: true
 
 - job:
     name: test-user-test-user-login-password-aws
@@ -182,10 +112,10 @@
       - integration-artifacts
 
 - job:
-    name: test-user-test-user-manage-lxd
+    name: test-user-test-user-login-password-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test test_user_manage in user suite on lxd
+      Test test_user_login_password in user suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -245,8 +175,8 @@
       - run-integration-test:
             test_name: 'user'
             setup_steps: ''
-            task_name: 'test_user_manage'
-            skip_tasks: 'test_user_login_password'
+            task_name: 'test_user_login_password'
+            skip_tasks: 'test_user_manage'
 
     publishers:
       - integration-artifacts
@@ -301,6 +231,76 @@
         default: 'us-east-1'
         description: 'Cloud Region to use when bootstrapping Juju'
         name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - run-integration-test:
+            test_name: 'user'
+            setup_steps: ''
+            task_name: 'test_user_manage'
+            skip_tasks: 'test_user_login_password'
+
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-user-test-user-manage-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test test_user_manage in user suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
     - string:
         default: ''
         description: 'Ubuntu series to use when bootstrapping Juju'

--- a/jobs/ci-run/unittest/unittests.yml
+++ b/jobs/ci-run/unittest/unittests.yml
@@ -33,9 +33,9 @@
             projects:
               - name: unit-tests-amd64
                 current-parameters: true
-              - name: unit-tests-race-amd64
-                current-parameters: true
               - name: unit-tests-arm64
+                current-parameters: true
+              - name: unit-tests-race-amd64
                 current-parameters: true
               - name: unit-tests-race-arm64
                 current-parameters: true

--- a/tests/suites/static_analysis/alphabetise/doc.go
+++ b/tests/suites/static_analysis/alphabetise/doc.go
@@ -1,0 +1,8 @@
+// Package alphabetise attempts to indentify any multijobs whose subjobs
+// are not listed in alphsbetical order. It does this by walking over all
+// builders, jobs and job-templates looking for multi-jobs.
+//
+// When a multijob is found, the `name` fields of the subjobs are extracted
+// and asserted to be ordered with sort.StringsAreSorted
+//
+package main

--- a/tests/suites/static_analysis/alphabetise/main.go
+++ b/tests/suites/static_analysis/alphabetise/main.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Node represents a job inside the yaml files.
+type Node struct {
+	Builder struct {
+		Name     string        `yaml:"name"`
+		Builders []interface{} `yaml:"builders"`
+	} `yaml:"builder"`
+	Job struct {
+		Name     string        `yaml:"name"`
+		Builders []interface{} `yaml:"builders"`
+	} `yaml:"job"`
+	JobTemplate struct {
+		Name     string        `yaml:"name"`
+		Builders []interface{} `yaml:"builders"`
+	} `yaml:"job-template"`
+	Project struct {
+		Name string        `yaml:"name"`
+		Jobs []interface{} `yaml:"jobs"`
+	} `yaml:"project"`
+}
+
+// Config represents the different ways to config the linter
+type Config struct {
+	Files struct {
+		Skip []string `yaml:"skip"`
+	} `yaml:"files"`
+	Jobs struct {
+		Ignore []string `yaml:"ignore"`
+	} `yaml:"jobs"`
+}
+
+func locateNonAlphabetisedMultijobs(builders []interface{}) (string, bool) {
+	for _, builder := range builders {
+		switch builder.(type) {
+		case map[interface{}]interface{}:
+			for k, v := range builder.(map[interface{}]interface{}) {
+				if k == "multijob" {
+					multijob := v.(map[interface{}]interface{})
+					names := extractMultiProjects(multijob)
+					if !sort.StringsAreSorted(names) {
+						return multijob["name"].(string), true
+					}
+				}
+			}
+		}
+	}
+	return "", false
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatal("expected directory argument only.")
+	}
+	dir := os.Args[1]
+
+	reader := bufio.NewReader(os.Stdin)
+	bytes, err := ioutil.ReadAll(reader)
+	if err != nil {
+		log.Fatal("unexpected config", err)
+	}
+	var config Config
+	if err := yaml.Unmarshal(bytes, &config); err != nil {
+		log.Fatal("config parse error", err)
+	}
+
+	var nonAlphabetisedMultijobs []string
+
+	if err := walkDirectory(dir, ignore(dir, config.Files.Skip, func(path string, info os.FileInfo) error {
+		data, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		var job []Node
+		err = yaml.Unmarshal(data, &job)
+		if err != nil {
+			return err
+		}
+
+		for _, v := range job {
+			if v.Builder.Name != "" {
+				if name, ok := locateNonAlphabetisedMultijobs(v.Builder.Builders); ok {
+					nonAlphabetisedMultijobs = append(nonAlphabetisedMultijobs, fmt.Sprintf("%s:%s", v.Builder.Name, name))
+				}
+				continue
+			}
+			if v.Job.Name != "" {
+				if name, ok := locateNonAlphabetisedMultijobs(v.Job.Builders); ok {
+					nonAlphabetisedMultijobs = append(nonAlphabetisedMultijobs, fmt.Sprintf("%s:%s", v.Job.Name, name))
+				}
+				continue
+			}
+			if v.JobTemplate.Name != "" {
+				if name, ok := locateNonAlphabetisedMultijobs(v.JobTemplate.Builders); ok {
+					nonAlphabetisedMultijobs = append(nonAlphabetisedMultijobs, fmt.Sprintf("%s:%s", v.JobTemplate.Name, name))
+				}
+				continue
+			}
+		}
+		return nil
+	})); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	sort.Strings(nonAlphabetisedMultijobs)
+
+	var results []string
+	for _, job := range nonAlphabetisedMultijobs {
+		if contains(config.Jobs.Ignore, job) {
+			continue
+		}
+		results = append(results, job)
+	}
+
+	if len(results) > 0 {
+		j, err := yaml.Marshal(struct {
+			Alphabetise []string `yaml:"alphabetise"`
+		}{
+			Alphabetise: results,
+		})
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		fmt.Println(string(j))
+		os.Exit(2)
+	}
+
+	os.Exit(0)
+}
+
+func extractMultiProjects(multijob map[interface{}]interface{}) []string {
+	var names []string
+	for k, v := range multijob {
+		if k == "projects" {
+			for _, v := range v.([]interface{}) {
+				m := v.(map[interface{}]interface{})
+				if name, ok := m["name"]; ok {
+					names = append(names, name.(string))
+				}
+			}
+		}
+	}
+	return names
+}
+
+func ignore(dir string, skip []string, fn func(string, os.FileInfo) error) func(string, os.FileInfo) error {
+	return func(path string, info os.FileInfo) error {
+		b, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		if contains(skip, b) {
+			return nil
+		}
+		return fn(path, info)
+	}
+}
+
+func walkDirectory(dir string, fn func(string, os.FileInfo) error) error {
+	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || (filepath.Ext(path) != ".yml" && filepath.Ext(path) != ".yaml") {
+			return nil
+		}
+
+		return fn(path, info)
+	})
+}
+
+func contains(a []string, b string) bool {
+	for _, v := range a {
+		if strings.TrimSpace(v) == b {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/suites/static_analysis/lint_yaml.sh
+++ b/tests/suites/static_analysis/lint_yaml.sh
@@ -135,6 +135,25 @@ EOF
   fi
 }
 
+run_yaml_alphabetise() {
+  OUT=$(go run tests/suites/static_analysis/alphabetise/main.go "$(pwd)" <<EOF 2>&1 || true
+files:
+  skip:
+    - .github/workflows/static-analysis.yml
+    - .github/workflows/local-deployment.yml
+jobs:
+  ignore: []
+EOF
+)
+  if [ -n "${OUT}" ]; then
+    echo ""
+    echo "$(red 'Found some issues:')"
+    echo "${OUT}"
+    exit 1
+  fi
+
+}
+
 test_static_analysis_yaml() {
   if [ "$(skip 'test_static_analysis_yaml')" ]; then
       echo "==> TEST SKIPPED: static yaml analysis"
@@ -169,6 +188,13 @@ test_static_analysis_yaml() {
       run "run_yaml_simplify"
     else
       echo "go not found, yaml simplify disabled"
+    fi
+
+    # YAML alphabetise
+    if which go >/dev/null 2>&1; then
+      run "run_yaml_alphabetise"
+    else
+      echo "go not found, yaml alphabetise disabled"
     fi
   )
 }

--- a/tools/gen-wire-tests/main.go
+++ b/tools/gen-wire-tests/main.go
@@ -134,17 +134,17 @@ func main() {
 		suiteNames = append(suiteNames, suiteName)
 
 		clouds := make([]Cloud, 0)
-		if !contains(config.Folders.SkipLXD, suiteName) {
-			clouds = append(clouds, lxd)
-		}
 		if !contains(config.Folders.SkipAWS, suiteName) {
 			clouds = append(clouds, aws)
+		}
+		if !contains(config.Folders.SkipAzure, suiteName) {
+			clouds = append(clouds, azure)
 		}
 		if !contains(config.Folders.SkipGoogle, suiteName) {
 			clouds = append(clouds, google)
 		}
-		if !contains(config.Folders.SkipAzure, suiteName) {
-			clouds = append(clouds, azure)
+		if !contains(config.Folders.SkipLXD, suiteName) {
+			clouds = append(clouds, lxd)
 		}
 		if !contains(config.Folders.SkipMicrok8s, suiteName) {
 			clouds = append(clouds, microk8s)


### PR DESCRIPTION
Previously this rule existed informally and wasn't enforced, leading to much frustration re-sorting them every now and then. So add this as a linting rule

### QA Steps

- `make static-analysis` should pass
- re-order a couple of jobs in some multijob. `make static-analysis` should now fail