### PR TITLE
[JUJU-1843] Fix syntax in man/test-kubeflow.yml

### DIFF
--- a/jobs/ci-run/integration/man/test-kubeflow.yml
+++ b/jobs/ci-run/integration/man/test-kubeflow.yml
@@ -70,8 +70,8 @@
       - ensure-aws-credentials
       - registry-setup
       - get-s3-build-payload-testing:
-            SHORT_GIT_COMMIT: "${{SHORT_GIT_COMMIT}}"
-            platform: "linux/${{BUILD_ARCH}}"
+            SHORT_GIT_COMMIT: "${SHORT_GIT_COMMIT}"
+            platform: "linux/${BUILD_ARCH}"
       - integration-test-runner:
             test_name: "kubeflow"
             task_name: ""


### PR DESCRIPTION
Some extra curl brackets had been copied over when they shouldn't have been