### PR TITLE
[JUJU-2450] Build dqlite static libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-STATIC_ANALYSIS_JOB ?=
-PUSH_JOB			?=
-PUSH_TARGET			?= "jobs/ci-run"
-JJB_CONF_PATH		?= jenkins-jjb
-JUJU_REPO_PATH		?= "${GOPATH}/src/github.com/juju/juju"
+STATIC_ANALYSIS_JOB 	?=
+IGNORE_STATIC_ANALYSIS	?=
+PUSH_JOB				?=
+PUSH_TARGET				?= "jobs/ci-run"
+JJB_CONF_PATH			?= jenkins-jjb
+JUJU_REPO_PATH			?= "${GOPATH}/src/github.com/juju/juju"
 
 cwd 			 = $(shell pwd)
 virtualenv_dir 	 = $(cwd)/venv
@@ -26,7 +27,11 @@ install-deps: ensure-venv
 	# Replace the last line to override the version.
 	find -wholename '*jenkins_jobs/modules/publishers.py' -print0 | xargs -0 sed -i '/info = registry.get_plugin_info("postbuildscript")/!b;n;n;c\    version = pkg_resources.parse_version("3.1.0")'
 
+ifdef IGNORE_STATIC_ANALYSIS 
+push:
+else
 push: static-analysis
+endif
 	. $(virtualenv_dir)/bin/activate; jenkins-jobs --conf "${JJB_CONF_PATH}" \
 		--user "${JENKINS_USER}" \
 		--password "${JENKINS_ACCESS_TOKEN}" \

--- a/jobs/ci-run/build/builddqlite.yml
+++ b/jobs/ci-run/build/builddqlite.yml
@@ -1,0 +1,146 @@
+- job:
+    name: build-dqlite
+    node: noop-parent-jobs
+    project-type: "multijob"
+    concurrent: true
+    description: |-
+      Build dqlite libraries for specified platform
+    wrappers:
+      - ansicolor
+      - workspace-cleanup
+      - timestamps
+      - build-name:
+          name: build-dqlite
+    parameters:
+      - validating-string:
+          description: The git short hash for the commit you wish to build
+          name: SHORT_GIT_COMMIT
+          regex: ^\S{7}$
+          msg: Enter a valid 7 char git sha
+    builders:
+      - get-build-details
+      - set-test-description
+      - multijob:
+          name: build-dqlite-runner
+          projects:
+            - name: build-dqlite-amd64
+              current-parameters: true
+              predefined-parameters: |-
+                GIT_COMMIT=${SHORT_GIT_COMMIT}
+            - name: build-dqlite-arm64
+              current-parameters: true
+              predefined-parameters: |-
+                GIT_COMMIT=${SHORT_GIT_COMMIT}
+
+- job:
+    name: build-dqlite-amd64
+    node: ephemeral-focal-8c-32g-amd64
+    concurrent: true
+    description: |-
+      Build dqlite libraries for specified platform
+    wrappers:
+      - ansicolor
+      - workspace-cleanup
+      - timestamps
+      - cirun-test-stuck-timeout
+    parameters:
+      - validating-string:
+          description: The git short hash for the commit you wish to build
+          name: SHORT_GIT_COMMIT
+          regex: ^\S{7}$
+          msg: Enter a valid 7 char git sha
+    builders:
+      - wait-for-cloud-init
+      - set-common-environment
+      - install-common-tools
+      - detect-commit-go-version
+      - setup-go-environment
+      - get-s3-source-payload
+      - make-dqlite
+      - upload-s3-dqlite:
+          arch: "amd64"
+
+- job:
+    name: build-dqlite-arm64
+    node: ephemeral-focal-8c-32g-arm64
+    concurrent: true
+    description: |-
+      Build dqlite libraries for specified platform
+    wrappers:
+      - ansicolor
+      - workspace-cleanup
+      - timestamps
+      - cirun-test-stuck-timeout
+    parameters:
+      - validating-string:
+          description: The git short hash for the commit you wish to build
+          name: SHORT_GIT_COMMIT
+          regex: ^\S{7}$
+          msg: Enter a valid 7 char git sha
+    builders:
+      - wait-for-cloud-init
+      - set-common-environment
+      - install-common-tools
+      - detect-commit-go-version
+      - setup-go-environment
+      - get-s3-source-payload
+      - make-dqlite
+      - upload-s3-dqlite:
+          arch: "arm64"
+
+- builder:
+    name: "make-dqlite"
+    builders:
+      - host-src-command:
+          src_command: !include-raw: ../scripts/snippet_make-dqlite-build.sh
+
+- builder:
+    name: "upload-s3-dqlite"
+    builders:
+      - install-s3cmd
+      - get-s3-creds
+      - shell: |-
+          #!/bin/bash
+          set -eu
+
+          if [ -z "{arch}" ]; then
+              echo "arch var is empty"
+              exit 1
+          fi
+
+          echo "Uploading dqlite binaries for {arch}"
+
+          DQLITE_BUILD_ARCH={arch}
+
+          PROJECT_DIR=${{GOPATH}}/src/github.com/juju/juju
+
+          DQLITE_ARCHIVE_DEPS_PATH=${{PROJECT_DIR}}/scripts/dqlite
+          DQLITE_ARCHIVE_NAME=dqlite-deps
+          DQLITE_ARCHIVE_PATH=${{DQLITE_ARCHIVE_DEPS_PATH}}/${{DQLITE_ARCHIVE_NAME}}.tar.bz2
+
+          DQLITE_S3_BUCKET=s3://dqlite-static-libs
+          DQLITE_S3_ARCHIVE_NAME=$(date -u +"%Y-%m-%d")-dqlite-deps-${{DQLITE_BUILD_ARCH}}.tar.bz2
+          DQLITE_S3_ARCHIVE_PATH=${{DQLITE_S3_BUCKET}}/${{DQLITE_S3_ARCHIVE_NAME}}
+
+          cp ${{DQLITE_ARCHIVE_PATH}} ${{DQLITE_ARCHIVE_PATH}}.latest
+
+          s3cmd --config $S3_CFG ls
+
+          echo "Uploading specific {arch} dqlite binary"
+
+          s3cmd --config $S3_CFG \
+            put \
+            --no-progress \
+            ${{DQLITE_ARCHIVE_PATH}} \
+            ${{DQLITE_S3_ARCHIVE_PATH}}
+
+          mv ${{DQLITE_ARCHIVE_PATH}}.latest ${{DQLITE_ARCHIVE_PATH}}
+
+          echo "Uploading specific latest dqlite binary"
+
+          s3cmd --config $S3_CFG \
+            put \
+            --no-progress \
+            ${{DQLITE_ARCHIVE_PATH}} \
+            ${{DQLITE_S3_BUCKET}}/latest-dqlite-deps-${{DQLITE_BUILD_ARCH}}.tar.bz2
+

--- a/jobs/ci-run/scripts/snippet_make-dqlite-build.sh
+++ b/jobs/ci-run/scripts/snippet_make-dqlite-build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -ex
+
+sudo su
+
+cd ${JUJU_SRC_PATH}
+make -j`nproc` dqlite-local-build

--- a/jobs/common/scripts/install-go.sh
+++ b/jobs/common/scripts/install-go.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux
+set -ex
 
 case $(uname -m) in
 
@@ -24,8 +24,8 @@ case $(uname -m) in
     ;;
 esac
 
-if [[ "$GOVERSION" == "''" ]]; then
-  echo "No GoVersion defined. Skip Go installation."
+if [ -z "${GOVERSION}" ]; then
+  echo "No GOVERSION defined. Skip Go installation."
   exit 0
 fi
 

--- a/jobs/github/github-check-merge.yml
+++ b/jobs/github/github-check-merge.yml
@@ -147,9 +147,6 @@
       - detect-merge-go-version
       - install-common-tools
       - shell: |-
-          echo "test"
-          echo "test"
-          echo "test"
           echo "${{GOVERSION}}"
       - conditional-step:
           condition-kind: shell

--- a/tests/suites/static_analysis/lint_yaml.sh
+++ b/tests/suites/static_analysis/lint_yaml.sh
@@ -38,6 +38,7 @@ files:
     - .github/workflows/local-deployment.yml
 jobs:
   ignore:
+    - build-dqlite
     - ci-build-juju
     - ci-gating-tests
     - ci-proving-ground-tests
@@ -108,6 +109,7 @@ files:
     - .github/workflows/local-deployment.yml
 jobs:
   ignore:
+    - build-dqlite:build-dqlite-runner
     # TODO (stickupkid): Clean these commands up and simplify the following jobs
     # so that they don't require a multi-job for no reason.
     - ci-build-juju:Packaging


### PR DESCRIPTION
The following builds the dqlite static libraries that can be downloaded when compiling the dqlite branch in juju/juju. This enables the developers of juju to not have to be worried about setting up a build farm for doing this.

We're still missing a lot of the architectures, but we can still move towards that in the future.

For now only amd64 and arm64 is being created here. This should allow us to start testing the dqlite branch on graviton in aws for example.