### PR TITLE
[JUJU-2627] Increase timeout to 120 for make check juju

### DIFF
--- a/jobs/github/mergejobs.yaml
+++ b/jobs/github/mergejobs.yaml
@@ -9,7 +9,7 @@
       - workspace-cleanup
       - timestamps
       - timeout:
-          timeout: 60
+          timeout: 120
           fail: true
           type: absolute
     parameters:
@@ -64,7 +64,7 @@
       - workspace-cleanup
       - timestamps
       - timeout:
-          timeout: 60
+          timeout: 120
           fail: true
           type: absolute
     parameters:
@@ -161,7 +161,7 @@
       - workspace-cleanup
       - timestamps
       - timeout:
-           timeout: 60
+           timeout: 120
            fail: true
            type: absolute
     builders:


### PR DESCRIPTION
Whilst we don't have any caching layer in for the musl building, we need to up the timeout for how long a job can take. Hopefully people will get annoyed with it and implement caching for it.