### PR TITLE
Fixes docker buildx problems in Jenkins.

### DIFF
--- a/jobs/common/scripts/setup_steps-install-docker.sh
+++ b/jobs/common/scripts/setup_steps-install-docker.sh
@@ -24,6 +24,7 @@ echo \
 sudo apt-get update
 echo "Installing docker"
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  docker-buildx-plugin \
   docker-ce \
   docker-ce-cli \
   containerd.io


### PR DESCRIPTION
Docker has added a new package for buildx to their Ubuntu deb repo's. We now need to install buildx support separately.