### PR TITLE
[JUJU-2609] Add s390x builder for dqlite

### DIFF
--- a/jobs/ci-run/build/builddqlite.yml
+++ b/jobs/ci-run/build/builddqlite.yml
@@ -35,6 +35,10 @@
               current-parameters: true
               predefined-parameters: |-
                 GIT_COMMIT=${SHORT_GIT_COMMIT}
+            - name: build-dqlite-s390x
+              current-parameters: true
+              predefined-parameters: |-
+                GIT_COMMIT=${SHORT_GIT_COMMIT}
 
 - job:
     name: build-dqlite-amd64
@@ -123,9 +127,40 @@
       - detect-commit-go-version
       - setup-go-environment
       - get-s3-source-payload
-      - cross-make-dqlite
+      - cross-make-dqlite:
+          arch: "ppc64el"
       - upload-s3-dqlite:
           arch: "ppc64el"
+
+- job:
+    name: build-dqlite-s390x
+    node: ephemeral-focal-8c-32g-amd64
+    concurrent: true
+    description: |-
+      Build dqlite libraries for specified platform
+    wrappers:
+      - ansicolor
+      - workspace-cleanup
+      - timestamps
+      - cirun-test-stuck-timeout
+    parameters:
+      - validating-string:
+          description: The git short hash for the commit you wish to build
+          name: SHORT_GIT_COMMIT
+          regex: ^\S{7}$
+          msg: Enter a valid 7 char git sha
+    builders:
+      - wait-for-cloud-init
+      - set-common-environment
+      - install-common-tools
+      - install-docker
+      - detect-commit-go-version
+      - setup-go-environment
+      - get-s3-source-payload
+      - cross-make-dqlite:
+          arch: "s390x"
+      - upload-s3-dqlite:
+          arch: "s390x"
 
 - builder:
     name: "cross-make-dqlite"

--- a/jobs/ci-run/scripts/snippet_cross-make-dqlite-build.sh
+++ b/jobs/ci-run/scripts/snippet_cross-make-dqlite-build.sh
@@ -5,7 +5,7 @@ set -ex
 sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
 sudo docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
-sudo docker run --mount "type=bind,source=${JUJU_SRC_PATH},target=/juju" multiarch/ubuntu-core:ppc64el-focal /bin/bash -c '
+sudo docker run --mount "type=bind,source=$JUJU_SRC_PATH,target=/juju" "multiarch/ubuntu-core:{arch}-focal" /bin/bash -c '
 apt-get update
 apt-get install sudo make -y
 cd /juju


### PR DESCRIPTION
Build inside of a docker container driven by qemu multiarch

Also change make target to dqlite-build instead of the removed target dqlite-local-build

## QA Steps

Run pipeline and verify it builds s390x dqlite and puts the tarball in s3