### PR TITLE
[JUJU-2700] Reverted refresh-multijob to CI

### DIFF
--- a/jobs/ci-run/integration/integrationtests.yml
+++ b/jobs/ci-run/integration/integrationtests.yml
@@ -154,6 +154,10 @@
               current-parameters: true
               predefined-parameters: |-
                 BUILD_ARCH=amd64
+            - name: 'test-refresh-multijob'
+              current-parameters: true
+              predefined-parameters: |-
+                BUILD_ARCH=amd64
             - name: 'test-relations-multijob'
               current-parameters: true
               predefined-parameters: |-


### PR DESCRIPTION
This PR reverts the `refresh` multijob to CI.