### PR TITLE
[JUJU-2770] Install musl & dqlite upfront

### DIFF
--- a/jobs/github/scripts/snippet_build_check-juju-juju.sh
+++ b/jobs/github/scripts/snippet_build_check-juju-juju.sh
@@ -15,6 +15,11 @@
     make install-dependencies || make install-dependencies
     make setup-lxd || true
 
+    if [ -d "./scripts/dqlite" ]; then
+        echo `date --rfc-3339=seconds` "installing musl"
+        sudo make MUSL_CROSS_COMPILE=0 musl-install dqlite-install || { echo "Failed to install musl"; exit 1; }
+    fi
+
     if [ -f go.mod ]; then
         go mod download
     fi


### PR DESCRIPTION
This PR allows jenkins to take advantage of https://github.com/juju/juju/pull/15180

Install musl & dqlite so that we can correctly control the version of musl installed when testing. The way we do this is to force through the non-cross-compilation to speed up tests in jenkins.