### PR TITLE
Create a musl build cache

### DIFF
--- a/jobs/ci-run/build/builddqlite.yml
+++ b/jobs/ci-run/build/builddqlite.yml
@@ -212,7 +212,7 @@
 
           echo "Uploading specific latest dqlite binary"
 
-          SUM=$(sha256sum ${FILE} | awk '{print $1}')
+          SUM=$(sha256sum ${{DQLITE_ARCHIVE_PATH}} | cut -d " " -f 1)
           s3cmd --config $S3_CFG \
             put \
             --no-progress \

--- a/jobs/ci-run/build/builddqlite.yml
+++ b/jobs/ci-run/build/builddqlite.yml
@@ -212,6 +212,12 @@
 
           echo "Uploading specific latest dqlite binary"
 
+          SUM=$(sha256sum ${FILE} | awk '{print $1}')
+          s3cmd --config $S3_CFG \
+            put \
+            --no-progress \
+            ${{DQLITE_ARCHIVE_PATH}} \
+            ${{DQLITE_S3_BUCKET}}/${{SUM}}.tar.bz2
           s3cmd --config $S3_CFG \
             put \
             --no-progress \

--- a/jobs/ci-run/build/buildmusl.yml
+++ b/jobs/ci-run/build/buildmusl.yml
@@ -1,0 +1,98 @@
+- job:
+    name: build-musl
+    node: noop-parent-jobs
+    project-type: "multijob"
+    concurrent: true
+    description: |-
+      Build musl
+    wrappers:
+      - ansicolor
+      - workspace-cleanup
+      - timestamps
+      - build-name:
+          name: build-musl
+    parameters:
+      - validating-string:
+          description: The git short hash for the commit you wish to build
+          name: SHORT_GIT_COMMIT
+          regex: ^\S{7}$
+          msg: Enter a valid 7 char git sha
+    builders:
+      - get-build-details
+      - set-test-description
+      - multijob:
+          name: build-musl-runner
+          projects:
+            - name: build-musl-amd64
+              current-parameters: true
+              predefined-parameters: |-
+                GIT_COMMIT=${SHORT_GIT_COMMIT}
+
+- job:
+    name: build-musl-amd64
+    node: ephemeral-focal-8c-32g-amd64
+    concurrent: true
+    description: |-
+      Build musl libraries for specified platform
+    wrappers:
+      - ansicolor
+      - workspace-cleanup
+      - timestamps
+      - cirun-test-stuck-timeout
+    parameters:
+      - validating-string:
+          description: The git short hash for the commit you wish to build
+          name: SHORT_GIT_COMMIT
+          regex: ^\S{7}$
+          msg: Enter a valid 7 char git sha
+    builders:
+      - wait-for-cloud-init
+      - set-common-environment
+      - install-common-tools
+      - detect-commit-go-version
+      - setup-go-environment
+      - get-s3-source-payload
+      - make-musl
+      - upload-s3-musl:
+          arch: "amd64"
+
+- builder:
+    name: "make-musl"
+    builders:
+      - host-src-command:
+          src_command: !include-raw: ../scripts/snippet_make-musl-build.sh
+
+- builder:
+    name: "upload-s3-musl"
+    builders:
+      - install-s3cmd
+      - get-s3-creds
+      - shell: |-
+          #!/bin/bash
+          set -eu
+
+          if [ -z "{arch}" ]; then
+              echo "arch var is empty"
+              exit 1
+          fi
+
+          echo "Uploading musl binaries for {arch}"
+
+          MUSL_BUILD_ARCH={arch}
+
+          DQLITE_S3_BUCKET=s3://dqlite-static-libs
+
+          PROJECT_DIR=${{GOPATH}}/src/github.com/juju/juju
+          DEPS_DIR_PATH=${{PROJECT_DIR}}/_deps
+
+          MUSL_DIR_PATH=${{DEPS_DIR_PATH}}/musl-${{MUSL_BUILD_ARCH}}
+
+          cd ${{DEPS_DIR_PATH}}
+          tar -cjvf musl-${{MUSL_BUILD_ARCH}}.tar.bz2 musl-${{MUSL_BUILD_ARCH}}
+
+          SUM=$(sha256sum musl-${{MUSL_BUILD_ARCH}}.tar.bz2 | cut -d " " -f 1)
+          s3cmd --config $S3_CFG \
+            put \
+            --no-progress \
+            musl-${{MUSL_BUILD_ARCH}}.tar.bz2 \
+            "${{DQLITE_S3_BUCKET}}/musl/$SUM.tar.bz2"

--- a/jobs/ci-run/scripts/snippet_make-musl-build.sh
+++ b/jobs/ci-run/scripts/snippet_make-musl-build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -ex
+
+sudo su
+
+cd ${JUJU_SRC_PATH}
+make -j`nproc` musl-install

--- a/tests/suites/static_analysis/lint_yaml.sh
+++ b/tests/suites/static_analysis/lint_yaml.sh
@@ -39,6 +39,7 @@ files:
 jobs:
   ignore:
     - build-dqlite
+    - build-musl
     - ci-build-juju
     - ci-gating-tests
     - ci-proving-ground-tests
@@ -110,6 +111,7 @@ files:
 jobs:
   ignore:
     - build-dqlite:build-dqlite-runner
+    - build-musl:build-musl-runner
     # TODO (stickupkid): Clean these commands up and simplify the following jobs
     # so that they don't require a multi-job for no reason.
     - ci-build-juju:Packaging


### PR DESCRIPTION
The following creates a musl build cache for amd64 as we can't use github action build caches. This will be the first experiment before doing the same thing for the jenkins jobs.