### PR TITLE
[JUJU-2886] Prebuild all the architectures when building musl

### DIFF
--- a/jobs/ci-run/build/builddqlite.yml
+++ b/jobs/ci-run/build/builddqlite.yml
@@ -94,12 +94,6 @@
       - upload-s3-dqlite:
           arch: "arm64"
 
-- builder:
-    name: "make-dqlite"
-    builders:
-      - host-src-command:
-          src_command: !include-raw: ../scripts/snippet_make-dqlite-build.sh
-
 - job:
     name: build-dqlite-ppc64el
     node: ephemeral-focal-8c-32g-amd64
@@ -161,12 +155,6 @@
           arch: "s390x"
 
 - builder:
-    name: "make-cross-dqlite"
-    builders:
-      - host-src-command:
-          src_command: !include-raw: ../scripts/snippet_make-dqlite-cross-build.sh
-
-- builder:
     name: "upload-s3-dqlite"
     builders:
       - install-s3cmd
@@ -191,18 +179,8 @@
           DQLITE_ARCHIVE_PATH=${{DQLITE_ARCHIVE_DEPS_PATH}}/${{DQLITE_ARCHIVE_NAME}}.tar.bz2
 
           DQLITE_S3_BUCKET=s3://dqlite-static-libs
-          DQLITE_S3_ARCHIVE_NAME=$(date -u +"%Y-%m-%d")-dqlite-deps-${{DQLITE_BUILD_ARCH}}.tar.bz2
-          DQLITE_S3_ARCHIVE_PATH=${{DQLITE_S3_BUCKET}}/${{DQLITE_S3_ARCHIVE_NAME}}
 
-          s3cmd --config $S3_CFG ls
-
-          echo "Uploading specific {arch} dqlite binary"
-
-          s3cmd --config $S3_CFG \
-            put \
-            --no-progress \
-            ${{DQLITE_ARCHIVE_PATH}} \
-            ${{DQLITE_S3_ARCHIVE_PATH}}
+          s3cmd --config $S3_CFG ls ${{DQLITE_S3_BUCKET}}
 
           echo "Uploading specific latest dqlite binary"
 
@@ -212,3 +190,21 @@
             --no-progress \
             ${{DQLITE_ARCHIVE_PATH}} \
             ${{DQLITE_S3_BUCKET}}/${{SUM}}.tar.bz2
+
+          echo "Uploaded ${{DQLITE_S3_BUCKET}}/${{SUM}}.tar.bz2"
+          echo " + sha256: ${{SUM}}"
+          echo ""
+
+          s3cmd --config $S3_CFG ls ${{DQLITE_S3_BUCKET}}
+
+- builder:
+    name: "make-dqlite"
+    builders:
+      - host-src-command:
+          src_command: !include-raw: ../scripts/snippet_make-dqlite-build.sh
+
+- builder:
+    name: "make-cross-dqlite"
+    builders:
+      - host-src-command:
+          src_command: !include-raw: ../scripts/snippet_make-dqlite-cross-build.sh

--- a/jobs/ci-run/build/buildmusl.yml
+++ b/jobs/ci-run/build/buildmusl.yml
@@ -50,7 +50,7 @@
       - ansicolor
       - workspace-cleanup
       - timestamps
-      - cirun-test-stuck-timeout
+      - musl-test-stuck-timeout
     parameters:
       - validating-string:
           description: The git short hash for the commit you wish to build
@@ -78,7 +78,7 @@
       - ansicolor
       - workspace-cleanup
       - timestamps
-      - cirun-test-stuck-timeout
+      - musl-test-stuck-timeout
     parameters:
       - validating-string:
           description: The git short hash for the commit you wish to build
@@ -106,7 +106,7 @@
       - ansicolor
       - workspace-cleanup
       - timestamps
-      - cirun-test-stuck-timeout
+      - musl-test-stuck-timeout
     parameters:
       - validating-string:
           description: The git short hash for the commit you wish to build
@@ -136,7 +136,7 @@
       - ansicolor
       - workspace-cleanup
       - timestamps
-      - cirun-test-stuck-timeout
+      - musl-test-stuck-timeout
     parameters:
       - validating-string:
           description: The git short hash for the commit you wish to build
@@ -212,3 +212,11 @@
     builders:
       - host-src-command:
           src_command: !include-raw: ../scripts/snippet_make-musl-cross-build.sh
+
+- wrapper:
+    name: 'musl-test-stuck-timeout'
+    wrappers:
+      - timeout:
+          timeout: 240
+          fail: true
+          type: absolute

--- a/jobs/ci-run/build/buildmusl.yml
+++ b/jobs/ci-run/build/buildmusl.yml
@@ -27,6 +27,18 @@
               current-parameters: true
               predefined-parameters: |-
                 GIT_COMMIT=${SHORT_GIT_COMMIT}
+            - name: build-musl-arm64
+              current-parameters: true
+              predefined-parameters: |-
+                GIT_COMMIT=${SHORT_GIT_COMMIT}
+            - name: build-musl-ppc64el
+              current-parameters: true
+              predefined-parameters: |-
+                GIT_COMMIT=${SHORT_GIT_COMMIT}
+            - name: build-musl-s390x
+              current-parameters: true
+              predefined-parameters: |-
+                GIT_COMMIT=${SHORT_GIT_COMMIT}
 
 - job:
     name: build-musl-amd64
@@ -56,11 +68,93 @@
       - upload-s3-musl:
           arch: "amd64"
 
-- builder:
-    name: "make-musl"
+- job:
+    name: build-musl-arm64
+    node: ephemeral-focal-8c-32g-arm64
+    concurrent: true
+    description: |-
+      Build musl libraries for specified platform
+    wrappers:
+      - ansicolor
+      - workspace-cleanup
+      - timestamps
+      - cirun-test-stuck-timeout
+    parameters:
+      - validating-string:
+          description: The git short hash for the commit you wish to build
+          name: SHORT_GIT_COMMIT
+          regex: ^\S{7}$
+          msg: Enter a valid 7 char git sha
     builders:
-      - host-src-command:
-          src_command: !include-raw: ../scripts/snippet_make-musl-build.sh
+      - wait-for-cloud-init
+      - set-common-environment
+      - install-common-tools
+      - detect-commit-go-version
+      - setup-go-environment
+      - get-s3-source-payload
+      - make-musl
+      - upload-s3-musl:
+          arch: "arm64"
+
+- job:
+    name: build-musl-ppc64el
+    node: ephemeral-focal-8c-32g-amd64
+    concurrent: true
+    description: |-
+      Build musl libraries for specified platform
+    wrappers:
+      - ansicolor
+      - workspace-cleanup
+      - timestamps
+      - cirun-test-stuck-timeout
+    parameters:
+      - validating-string:
+          description: The git short hash for the commit you wish to build
+          name: SHORT_GIT_COMMIT
+          regex: ^\S{7}$
+          msg: Enter a valid 7 char git sha
+    builders:
+      - wait-for-cloud-init
+      - set-common-environment
+      - install-common-tools
+      - install-docker
+      - detect-commit-go-version
+      - setup-go-environment
+      - get-s3-source-payload
+      - make-cross-musl:
+          arch: "ppc64el"
+      - upload-s3-musl:
+          arch: "ppc64el"
+
+- job:
+    name: build-musl-s390x
+    node: ephemeral-focal-8c-32g-amd64
+    concurrent: true
+    description: |-
+      Build musl libraries for specified platform
+    wrappers:
+      - ansicolor
+      - workspace-cleanup
+      - timestamps
+      - cirun-test-stuck-timeout
+    parameters:
+      - validating-string:
+          description: The git short hash for the commit you wish to build
+          name: SHORT_GIT_COMMIT
+          regex: ^\S{7}$
+          msg: Enter a valid 7 char git sha
+    builders:
+      - wait-for-cloud-init
+      - set-common-environment
+      - install-common-tools
+      - install-docker
+      - detect-commit-go-version
+      - setup-go-environment
+      - get-s3-source-payload
+      - make-cross-musl:
+          arch: "s390x"
+      - upload-s3-musl:
+          arch: "s390x"
 
 - builder:
     name: "upload-s3-musl"
@@ -90,9 +184,31 @@
           cd ${{DEPS_DIR_PATH}}
           tar -cjvf musl-${{MUSL_BUILD_ARCH}}.tar.bz2 musl-${{MUSL_BUILD_ARCH}}
 
+          s3cmd --config $S3_CFG ls ${{DQLITE_S3_BUCKET}}/musl
+
+          echo "Uploading specific latest musl binary"
+
           SUM=$(sha256sum musl-${{MUSL_BUILD_ARCH}}.tar.bz2 | cut -d " " -f 1)
           s3cmd --config $S3_CFG \
             put \
             --no-progress \
             musl-${{MUSL_BUILD_ARCH}}.tar.bz2 \
             "${{DQLITE_S3_BUCKET}}/musl/$SUM.tar.bz2"
+
+          echo "Uploaded ${{DQLITE_S3_BUCKET}}/musl/${{SUM}}.tar.bz2"
+          echo " + sha256: ${{SUM}}"
+          echo ""
+
+          s3cmd --config $S3_CFG ls ${{DQLITE_S3_BUCKET}}/musl
+
+- builder:
+    name: "make-musl"
+    builders:
+      - host-src-command:
+          src_command: !include-raw: ../scripts/snippet_make-musl-build.sh
+
+- builder:
+    name: "make-cross-musl"
+    builders:
+      - host-src-command:
+          src_command: !include-raw: ../scripts/snippet_make-musl-cross-build.sh

--- a/jobs/ci-run/scripts/snippet_make-musl-build.sh
+++ b/jobs/ci-run/scripts/snippet_make-musl-build.sh
@@ -5,4 +5,4 @@ set -ex
 sudo su
 
 cd ${JUJU_SRC_PATH}
-make -j`nproc` musl-install
+make -j`nproc` MUSL_PRECOMPILED=0 musl-install

--- a/jobs/ci-run/scripts/snippet_make-musl-cross-build.sh
+++ b/jobs/ci-run/scripts/snippet_make-musl-cross-build.sh
@@ -6,8 +6,10 @@ sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
 sudo docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
 sudo docker run --mount "type=bind,source=$JUJU_SRC_PATH,target=/juju" "multiarch/ubuntu-core:{arch}-focal" /bin/bash -c '
+DEBIAN_FRONTEND=noninteractive
+TZ=Europe/London
 apt-get update
-apt-get install sudo make -y
+apt-get install sudo build-essential golang-go git curl wget -y
 cd /juju
 make -j`nproc` MUSL_PRECOMPILED=0 musl-install
 '

--- a/jobs/ci-run/scripts/snippet_make-musl-cross-build.sh
+++ b/jobs/ci-run/scripts/snippet_make-musl-cross-build.sh
@@ -6,8 +6,8 @@ sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
 sudo docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
 sudo docker run --mount "type=bind,source=$JUJU_SRC_PATH,target=/juju" "multiarch/ubuntu-core:{arch}-focal" /bin/bash -c '
-DEBIAN_FRONTEND=noninteractive
-TZ=Europe/London
+export DEBIAN_FRONTEND=noninteractive
+export TZ=Europe/London
 apt-get update
 apt-get install sudo build-essential golang-go git curl wget -y
 cd /juju

--- a/jobs/ci-run/scripts/snippet_make-musl-cross-build.sh
+++ b/jobs/ci-run/scripts/snippet_make-musl-cross-build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -ex
+
+sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
+sudo docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+sudo docker run --mount "type=bind,source=$JUJU_SRC_PATH,target=/juju" "multiarch/ubuntu-core:{arch}-focal" /bin/bash -c '
+apt-get update
+apt-get install sudo make -y
+cd /juju
+make -j`nproc` MUSL_PRECOMPILED=0 musl-install
+'


### PR DESCRIPTION
The following will speed up all deployments and CI jobs, as we'll now have precompiled musl compilers for each architecture. Luckily we can piggyback off the dqlite jobs and just replicate what they have. In the back of my mind, I should try and combine them, but actually, that leads to very complicated jjb setups, and the simpler the better

See it running: https://jenkins.juju.canonical.com/job/build-musl/