### PR TITLE
Set GOOS and GOARCH correctly

### DIFF
--- a/jobs/ci-run/scripts/snippet_make-release-build.sh
+++ b/jobs/ci-run/scripts/snippet_make-release-build.sh
@@ -9,4 +9,11 @@ echo AGENT_PACKAGE_PLATFORMS=${{AGENT_PACKAGE_PLATFORMS}}
 echo BUILD_TAGS=${{BUILD_TAGS:-}}
 
 cd ${{JUJU_SRC_PATH}}
-make -j`nproc` go-build BUILD_TAGS="${{BUILD_TAGS:-}}"
+build_type=$(grep "go-agent-build-no-cgo" Makefile >/dev/null && echo "no-cgo")
+if [ $build_type = "no-cgo" ]; then
+    GOOS=$(echo $AGENT_PACKAGE_PLATFORMS | cut -d/ -f 1) \
+    GOARCH=$(echo $AGENT_PACKAGE_PLATFORMS | cut -d/ -f 2) \
+        make -j`nproc` go-build BUILD_TAGS="${{BUILD_TAGS:-}}"
+else
+    make -j`nproc` go-build BUILD_TAGS="${{BUILD_TAGS:-}}"
+fi


### PR DESCRIPTION
We need to set these up correctly so that dqlite and musl dependencies are correctly picked up when downloading.

This should fix the CI build issues.