### PR TITLE
GOARCH ppc64el fix

### DIFF
--- a/jobs/ci-run/scripts/snippet_make-release-build.sh
+++ b/jobs/ci-run/scripts/snippet_make-release-build.sh
@@ -12,7 +12,7 @@ cd ${{JUJU_SRC_PATH}}
 build_type=$(grep "go-agent-build-no-cgo" Makefile >/dev/null && echo "no-cgo")
 if [ $build_type = "no-cgo" ]; then
     GOOS=$(echo $AGENT_PACKAGE_PLATFORMS | cut -d/ -f 1) \
-    GOARCH=$(echo $AGENT_PACKAGE_PLATFORMS | cut -d/ -f 2) \
+    GOARCH=$(echo $AGENT_PACKAGE_PLATFORMS | cut -d/ -f 2 | sed "s/ppc64el/ppc64le/") \
         make -j`nproc` go-build BUILD_TAGS="${{BUILD_TAGS:-}}"
 else
     make -j`nproc` go-build BUILD_TAGS="${{BUILD_TAGS:-}}"


### PR DESCRIPTION
The following normalizes the ppc64el to ppc64le as a lot of the architectures swap them interchangably.