### PR TITLE
Fix the build-type query

### DIFF
--- a/jobs/ci-run/scripts/snippet_make-release-build.sh
+++ b/jobs/ci-run/scripts/snippet_make-release-build.sh
@@ -9,7 +9,7 @@ echo AGENT_PACKAGE_PLATFORMS=${{AGENT_PACKAGE_PLATFORMS}}
 echo BUILD_TAGS=${{BUILD_TAGS:-}}
 
 cd ${{JUJU_SRC_PATH}}
-build_type=$(grep "go-agent-build-no-cgo" Makefile >/dev/null && echo "no-cgo")
+build_type=$(grep "go-agent-build-no-cgo" Makefile >/dev/null && echo "no-cgo" || echo "")
 if [ $build_type = "no-cgo" ]; then
     GOOS=$(echo $AGENT_PACKAGE_PLATFORMS | cut -d/ -f 1) \
     GOARCH=$(echo $AGENT_PACKAGE_PLATFORMS | cut -d/ -f 2 | sed "s/ppc64el/ppc64le/") \


### PR DESCRIPTION
If the build-type is not valid it will cause it to error out and exit 1 based on the set flags. The fix is to provide an OR clause.

This will break any release that isn't 3.2.

See: https://github.com/canonical/juju-release-jenkins/pull/70