### PR TITLE
[JUJU-3455] Fix user and password retrieval for azure login

### DIFF
--- a/jobs/ci-run/integration/common/test-runner.sh
+++ b/jobs/ci-run/integration/common/test-runner.sh
@@ -76,8 +76,8 @@ while [ $attempts -lt 3 ]; do
         fi
 
         az login --service-principal \
-          -u "$(cat "$HOME"/.local/share/juju/credentials.yaml | yq ".credentials.azure.juju-qa.application-id")" \
-          -p "$(cat "$HOME"/.local/share/juju/credentials.yaml | yq ".credentials.azure.juju-qa.application-password")" \
+          -u "$(cat "$HOME"/.local/share/juju/credentials.yaml | yq ".credentials.azure.credentials.application-id")" \
+          -p "$(cat "$HOME"/.local/share/juju/credentials.yaml | yq ".credentials.azure.credentials.application-password")" \
           --tenant "${{AZURE_TENANT}}"
     fi
     attempts=$((attempts + 1))


### PR DESCRIPTION
The yq path used to retrieve the username and password for Azure cloud login (`az login`) was incorrect. The fix is simply on the path from `yq ".credentials.azure.juju-qa.application-id"` to `yq ".credentials.azure.credentials.application-id"` for `az login`.