### PR TITLE
[JUJU-3513] Fix unstable tests issue in qa-jenkins

### DIFF
--- a/jobs/ci-run/integration/gen/test-deploy-unstable.yml
+++ b/jobs/ci-run/integration/gen/test-deploy-unstable.yml
@@ -36,3 +36,7 @@
           current-parameters: true
         - name: 'test-deploy-test-deploy-charms-lxd'
           current-parameters: true
+        - name: 'test-deploy-test-deploy-os-aws'
+          current-parameters: true
+        - name: 'test-deploy-test-deploy-revision-aws'
+          current-parameters: true

--- a/jobs/ci-run/integration/gen/test-deploy.yml
+++ b/jobs/ci-run/integration/gen/test-deploy.yml
@@ -44,11 +44,7 @@
           current-parameters: true
         - name: 'test-deploy-test-deploy-default-series-lxd'
           current-parameters: true
-        - name: 'test-deploy-test-deploy-os-aws'
-          current-parameters: true
         - name: 'test-deploy-test-deploy-os-lxd'
-          current-parameters: true
-        - name: 'test-deploy-test-deploy-revision-aws'
           current-parameters: true
         - name: 'test-deploy-test-deploy-revision-lxd'
           current-parameters: true

--- a/jobs/ci-run/integration/gen/test-model-unstable.yml
+++ b/jobs/ci-run/integration/gen/test-model-unstable.yml
@@ -32,13 +32,33 @@
     - multijob:
         name: 'IntegrationTests-model'
         projects:
+        - name: 'test-model-test-model-config-aws'
+          current-parameters: true
+        - name: 'test-model-test-model-config-google'
+          current-parameters: true
         - name: 'test-model-test-model-config-lxd'
+          current-parameters: true
+        - name: 'test-model-test-model-metrics-aws'
+          current-parameters: true
+        - name: 'test-model-test-model-metrics-google'
           current-parameters: true
         - name: 'test-model-test-model-metrics-lxd'
           current-parameters: true
+        - name: 'test-model-test-model-migration-saas-common-aws'
+          current-parameters: true
+        - name: 'test-model-test-model-migration-saas-common-google'
+          current-parameters: true
         - name: 'test-model-test-model-migration-saas-common-lxd'
           current-parameters: true
+        - name: 'test-model-test-model-migration-saas-external-aws'
+          current-parameters: true
+        - name: 'test-model-test-model-migration-saas-external-google'
+          current-parameters: true
         - name: 'test-model-test-model-migration-saas-external-lxd'
+          current-parameters: true
+        - name: 'test-model-test-model-multi-aws'
+          current-parameters: true
+        - name: 'test-model-test-model-multi-google'
           current-parameters: true
         - name: 'test-model-test-model-multi-lxd'
           current-parameters: true

--- a/jobs/ci-run/integration/gen/test-model.yml
+++ b/jobs/ci-run/integration/gen/test-model.yml
@@ -32,19 +32,11 @@
     - multijob:
         name: 'IntegrationTests-model'
         projects:
-        - name: 'test-model-test-model-config-aws'
-          current-parameters: true
-        - name: 'test-model-test-model-config-google'
-          current-parameters: true
         - name: 'test-model-test-model-destroy-aws'
           current-parameters: true
         - name: 'test-model-test-model-destroy-google'
           current-parameters: true
         - name: 'test-model-test-model-destroy-lxd'
-          current-parameters: true
-        - name: 'test-model-test-model-metrics-aws'
-          current-parameters: true
-        - name: 'test-model-test-model-metrics-google'
           current-parameters: true
         - name: 'test-model-test-model-migration-aws'
           current-parameters: true
@@ -52,23 +44,11 @@
           current-parameters: true
         - name: 'test-model-test-model-migration-lxd'
           current-parameters: true
-        - name: 'test-model-test-model-migration-saas-common-aws'
-          current-parameters: true
-        - name: 'test-model-test-model-migration-saas-common-google'
-          current-parameters: true
-        - name: 'test-model-test-model-migration-saas-external-aws'
-          current-parameters: true
-        - name: 'test-model-test-model-migration-saas-external-google'
-          current-parameters: true
         - name: 'test-model-test-model-migration-version-aws'
           current-parameters: true
         - name: 'test-model-test-model-migration-version-google'
           current-parameters: true
         - name: 'test-model-test-model-migration-version-lxd'
-          current-parameters: true
-        - name: 'test-model-test-model-multi-aws'
-          current-parameters: true
-        - name: 'test-model-test-model-multi-google'
           current-parameters: true
         - name: 'test-model-test-model-status-aws'
           current-parameters: true

--- a/jobs/ci-run/integration/gen/test-user-unstable.yml
+++ b/jobs/ci-run/integration/gen/test-user-unstable.yml
@@ -32,5 +32,7 @@
     - multijob:
         name: 'IntegrationTests-user'
         projects:
+        - name: 'test-user-test-user-login-password-aws'
+          current-parameters: true
         - name: 'test-user-test-user-login-password-lxd'
           current-parameters: true

--- a/jobs/ci-run/integration/gen/test-user.yml
+++ b/jobs/ci-run/integration/gen/test-user.yml
@@ -32,8 +32,6 @@
     - multijob:
         name: 'IntegrationTests-user'
         projects:
-        - name: 'test-user-test-user-login-password-aws'
-          current-parameters: true
         - name: 'test-user-test-user-manage-aws'
           current-parameters: true
         - name: 'test-user-test-user-manage-lxd'

--- a/tools/gen-wire-tests/main.go
+++ b/tools/gen-wire-tests/main.go
@@ -391,7 +391,7 @@ const Template = `
         projects:
 {{- range $k, $skip_tasks := $node.SkipTasks}}
 {{- range $cloud := $node.Clouds}}
-    {{- $unstableTasks := index $node.UnstableTasks $cloud.ProviderName -}}
+    {{- $unstableTasks := index $node.UnstableTasks $cloud.CloudName -}}
     {{- $task_name := index $node.TaskNames $k -}}
     {{- if eq (contains $unstableTasks $task_name) $node.Unstable}}
         - name: 'test-{{$.SuiteName}}-{{ensureHyphen $task_name}}-{{$cloud.CloudName}}'


### PR DESCRIPTION
This PR updates the test handling by using CloudName to operate with unstable tests. Additionally, it regenerates the gen-wire-tests to ensure up-to-date and accurate test results.