### PR TITLE
[JUJU-3526] Move test-ck to proving ground CI test group

### DIFF
--- a/jobs/ci-run/integration/integrationtests.yml
+++ b/jobs/ci-run/integration/integrationtests.yml
@@ -98,10 +98,6 @@
               current-parameters: true
               predefined-parameters: |-
                 BUILD_ARCH=amd64
-            - name: 'test-ck'
-              current-parameters: true
-              predefined-parameters: |-
-                BUILD_ARCH=amd64
             - name: 'test-cli-multijob'
               current-parameters: true
               predefined-parameters: |-
@@ -236,6 +232,10 @@
       - multijob:
           name: proving-grounds-integration-tests-amd64
           projects:
+            - name: 'test-ck'
+              current-parameters: true
+              predefined-parameters: |-
+                BUILD_ARCH=amd64
             - name: 'test-coslite-multijob'
               current-parameters: true
               predefined-parameters: |-


### PR DESCRIPTION
This PR relocates the `test-ck` module to the proving ground CI test group, because these are issues that need to be fixed on CK side (to work correctly on the Azure cloud provider).