### PR TITLE
Run proving ground once per version per day.

### DIFF
--- a/jobs/ci-run/ci-run-proving-grounds-tests.yml
+++ b/jobs/ci-run/ci-run-proving-grounds-tests.yml
@@ -77,9 +77,14 @@
           command: |
             import hudson.model.*
 
+            def desc = build.getDescription().split(":")
+            def jujuVersion = desc[0]
+
+            println "Looking for $jujuVersion in previous builds..."
+
             def b = build.getPreviousBuild()
             while (b != null) {
-                if (b.result != Result.SUCCESS) {
+                if (b.result != Result.SUCCESS || b.getDescription() == null || b.getDescription().indexOf(jujuVersion) == -1) {
                     b = b.getPreviousBuild()
                     continue
                 }


### PR DESCRIPTION
Run proving ground once per juju version per day, so that we can see how tests improve over time.
This is a hack to get the juju version as it isn't available via the envvars or build vars for some reason.