### PR TITLE
Ensure query_tracing test is only done on 3.2+

### DIFF
--- a/jobs/ci-run/integration/gen/test-controller.yml
+++ b/jobs/ci-run/integration/gen/test-controller.yml
@@ -404,11 +404,17 @@
     builders:
       - wait-for-cloud-init
       - prepare-integration-test
-      - run-integration-test:
-            test_name: 'controller'
-            setup_steps: ''
-            task_name: 'test_query_tracing'
-            skip_tasks: 'test_enable_ha,test_mongo_memory_profile'
+      - conditional-step:
+          condition-kind: regex-match
+          regex: "^[4-9].*|^3\\.([2-9]|\\d{2,})(\\.|-).*"
+          label: "${JUJU_VERSION}"
+          on-evaluation-failure: "dont-run"
+          steps:
+            - run-integration-test:
+                  test_name: 'controller'
+                  setup_steps: ''
+                  task_name: 'test_query_tracing'
+                  skip_tasks: 'test_enable_ha,test_mongo_memory_profile'
     publishers:
       - integration-artifacts
 
@@ -475,10 +481,16 @@
     builders:
       - wait-for-cloud-init
       - prepare-integration-test
-      - run-integration-test:
-            test_name: 'controller'
-            setup_steps: ''
-            task_name: 'test_query_tracing'
-            skip_tasks: 'test_enable_ha,test_mongo_memory_profile'
+      - conditional-step:
+          condition-kind: regex-match
+          regex: "^[4-9].*|^3\\.([2-9]|\\d{2,})(\\.|-).*"
+          label: "${JUJU_VERSION}"
+          on-evaluation-failure: "dont-run"
+          steps:
+            - run-integration-test:
+                  test_name: 'controller'
+                  setup_steps: ''
+                  task_name: 'test_query_tracing'
+                  skip_tasks: 'test_enable_ha,test_mongo_memory_profile'
     publishers:
       - integration-artifacts

--- a/jobs/ci-run/integration/gen/test-firewall.yml
+++ b/jobs/ci-run/integration/gen/test-firewall.yml
@@ -258,7 +258,7 @@
       - prepare-integration-test
       - conditional-step:
           condition-kind: regex-match
-          regex: "^[4-9]|^3\\.([2-9]|\\d{2,})(\\.|-).*"
+          regex: "^[4-9].*|^3\\.([2-9]|\\d{2,})(\\.|-).*"
           label: "${JUJU_VERSION}"
           on-evaluation-failure: "dont-run"
           steps:

--- a/tools/gen-wire-tests/juju.config
+++ b/tools/gen-wire-tests/juju.config
@@ -2,6 +2,8 @@ folders:
   introduced:
     test_firewall_ssh:
       3.2
+    test_query_tracing:
+      3.2
   timeout:
     model:
       test_model_migration: 90


### PR DESCRIPTION
The following just ensures that new 3.2 query_tracing test isn't run on anything but 3.2 and later.