### PR TITLE
Added support for quick merges.

### DIFF
--- a/jobs/common/pre-reqs.yaml
+++ b/jobs/common/pre-reqs.yaml
@@ -238,20 +238,6 @@
         sudo pip3 install apache-libcloud;
 
 - builder:
-    name: install-aks-libs
-    builders:
-    - shell: |-
-        #!/bin/bash
-        set -xeu
-
-        sudo DEBIAN_FRONTEND=noninteractive apt update;
-        sudo DEBIAN_FRONTEND=noninteractive apt install -y python3-pip;
-        sudo apt install -y python3-dev
-        sudo pip3 install azure-identity;
-        sudo pip3 install azure-mgmt-containerservice;
-        sudo pip3 install msrestazure;
-
-- builder:
     name: install-equinix-libs
     builders:
     - shell: |-
@@ -272,24 +258,6 @@
 
         cd scripts
         git checkout origin/main -- jobs/z-jobs/scripts/clean_lxd.py
-        cd ${WORKSPACE}
-    - inject:
-        properties-content: |-
-            SCRIPTS_DIR=${WORKSPACE}/scripts/jobs/z-jobs/scripts/
-
-- builder:
-    name: get-aks-cleanup-scripts
-    builders:
-    - checkout-qa-repo
-    - install-aks-libs
-    - shell: |-
-        #!/bin/bash
-        set -eux
-
-        sudo pip3 install backports-datetime-fromisoformat
-
-        cd scripts
-        git checkout origin/main -- jobs/z-jobs/scripts/aks_cleanup.py
         cd ${WORKSPACE}
     - inject:
         properties-content: |-

--- a/jobs/github/github-check-merge.yml
+++ b/jobs/github/github-check-merge.yml
@@ -144,6 +144,7 @@
     builders:
       - wait-for-cloud-init
       - set-common-environment
+      - resolve-merge-commit
       - detect-merge-go-version
       - install-common-tools
       - shell: |-
@@ -246,6 +247,7 @@
     builders:
       - wait-for-cloud-init
       - set-common-environment
+      - resolve-merge-commit
       - detect-merge-go-version
       - install-common-tools
       - conditional-step:

--- a/jobs/github/mergejobs.yaml
+++ b/jobs/github/mergejobs.yaml
@@ -39,18 +39,18 @@
           black-list-labels:
             - "no-test-run"
           black-list-target-branches:
-            - master
-            - staging
-            - jucy-lucy
             - feature-.*
     builders:
+      - resolve-merge-commit
       - detect-merge-go-version
       - multijob:
           name: github-juju-check-jobs
           projects:
             - name: github-make-check-juju
               current-parameters: true
-              predefined-parameters: GOVERSION=${GOVERSION}
+              predefined-parameters: |-
+                GOVERSION=${GOVERSION}
+                MERGE_COMMIT=${MERGE_COMMIT}
 
 
 - job:   # github-juju-merge-jobs
@@ -91,9 +91,6 @@
             - CanonicalLtd
           allow-whitelist-orgs-as-admins: true
           black-list-target-branches:
-            - master
-            - staging
-            - jucy-lucy
             - feature-.*
     builders:
       - shell: |-
@@ -106,13 +103,18 @@
           EOT
       - inject:
           properties-file: ${WORKSPACE}/prdesc
+      - resolve-merge-commit
       - detect-merge-go-version
+      - should-skip-juju-make-check
       - multijob:
           name: github-juju-merge-jobs
           projects:
             - name: github-make-check-juju
+              enable-condition: '!"${SKIP_CHECK}".equals("1")'
               current-parameters: true
-              predefined-parameters: GOVERSION=${GOVERSION}
+              predefined-parameters: |-
+                GOVERSION=${GOVERSION}
+                MERGE_COMMIT=${MERGE_COMMIT}
       - get-github-token
       - github-merge:
           merge_comment: |-
@@ -146,8 +148,8 @@
     parameters:
     - string:
         default: ''
-        description: 'Specific git SHA to build (used to overwrite triggered runs).'
-        name: GITHUB_BRANCH_HEAD_SHA
+        description: 'Pseudo merge commit for this PR check run'
+        name: MERGE_COMMIT
     - string:
         default: ''
         description: 'Go version used for build.'
@@ -165,8 +167,7 @@
            fail: true
            type: absolute
     builders:
-      - description-setter:
-          description: '<a href="${ghprbPullLink}">PR #${ghprbPullId}</a>'
+      - set-check-description
       - install-go
       - shell: |-
           #!/bin/bash
@@ -196,96 +197,3 @@
       - junit:
           results: tests.xml
           allow-empty-results: true
-
-
-############################################################# PYLIBJUJU TESTS ##
-
-# - job:   # github-juju-pylibjuju-jobs
-#     name: 'github-juju-pylibjuju-jobs'
-#     project-type: 'multijob'
-#     description: 'Run the pylibjuju checks for the GitHub PR'
-#     concurrent: true
-#     node: noop-parent-jobs
-#     wrappers:
-#       - ansicolor
-#       - workspace-cleanup
-#       - timestamps
-#       - timeout:
-#           timeout: 60
-#           fail: true
-#           type: absolute
-#     parameters:
-#     - string:
-#          default: ''
-#          description: 'Enable sub job to be run individually.'
-#          name: SHORT_GIT_COMMIT
-#     properties:
-#       - github:
-#           url: https://github.com/juju/juju/
-#       - authorization:
-#           anonymous:
-#             - job-read
-#     triggers:
-#       - github-pull-request:
-#           github-hooks: true
-#           trigger-phrase: '.*(jenkins\:.*test.*schema)|(##.*##).*'
-#           status-context: "check-multi-pylibjuju-tests"
-#           only-trigger-phrase: true
-#           auto-close-on-fail: false
-#           cancel-builds-on-update: true  # Cancel existing builds if PR updated/re-run.
-#           org-list:
-#             - juju
-#             - CanonicalLtd
-#           allow-whitelist-orgs-as-admins: true
-#           black-list-labels:
-#             - "no-test-run"
-#           black-list-target-branches:
-#             - master
-#             - staging
-#             - jucy-lucy
-#             - feature-.*
-#     builders:
-#       - multijob:
-#             name: github-juju-pylibjuju-jobs
-#             projects:
-#               - name: github-schema-tests-pylibjuju
-#                 current-parameters: true
-
-# - job:
-#     name: github-schema-tests-pylibjuju
-#     description: |-
-#       Run schema checks against python libjuju against the PR
-#     node: ephemeral-github-medium-amd64
-#     concurrent: false
-#     parameters:
-#     - string:
-#         default: ''
-#         description: 'Specific git SHA to build (used to overwrite triggered runs).'
-#         name: GITHUB_BRANCH_HEAD_SHA
-#     properties:
-#       - authorization:
-#          anonymous:
-#              - job-read
-#     wrappers:
-#       - ansicolor
-#       - workspace-cleanup
-#       - timestamps
-#       - timeout:
-#            timeout: 60
-#            fail: true
-#            type: absolute
-#     builders:
-#       - description-setter:
-#           description: '<a href="${ghprbPullLink}">PR #${ghprbPullId}</a>'
-#       - inject:
-#           properties-content: |-
-#             PROJECT_DIR="github.com/juju/juju"
-#       - run-build-check-raw:
-#           build_env: ""
-#           setup_steps: ""
-#           checkout_command:
-#               !include-raw: "./scripts/checkout.sh"
-#           src_command:
-#               !include-raw: "./scripts/snippet_clean-test-exit.sh"
-#           test_command:
-#               !include-raw: "./scripts/pylibjuju-schema-test.sh"

--- a/jobs/github/mgo_mergejobs.yaml
+++ b/jobs/github/mgo_mergejobs.yaml
@@ -41,6 +41,7 @@
           black-list-target-branches:
             - feature-.*
     builders:
+      - resolve-merge-commit
       - detect-merge-go-version
       - multijob:
           name: github-mgo-check-jobs
@@ -49,6 +50,7 @@
               current-parameters: true
               predefined-parameters: |-
                 GOVERSION=${GOVERSION}
+                MERGE_COMMIT=${MERGE_COMMIT}
 
 - job:
     name: github-make-check-mgo
@@ -58,9 +60,9 @@
     concurrent: true
     parameters:
       - string:
-          default: ""
-          description: "Specific git SHA to build (used to overwrite triggered runs)."
-          name: GITHUB_BRANCH_HEAD_SHA
+          default: ''
+          description: 'Pseudo merge commit for this PR check run'
+          name: MERGE_COMMIT
       - string:
           default: ""
           description: "Specify the OS Series to run on"
@@ -82,8 +84,7 @@
           fail: true
           type: absolute
     builders:
-      - description-setter:
-          description: '<a href="${ghprbPullLink}">PR #${ghprbPullId}</a>'
+      - set-check-description
       - install-go
       - install-mongo4.4
       - inject:
@@ -148,6 +149,7 @@
           EOT
       - inject:
           properties-file: ${WORKSPACE}/prdesc
+      - resolve-merge-commit
       - detect-merge-go-version
       - multijob:
           name: github-mgo-merge-jobs
@@ -156,6 +158,7 @@
               current-parameters: true
               predefined-parameters: |-
                 GOVERSION=${GOVERSION}
+                MERGE_COMMIT=${MERGE_COMMIT}
     publishers:
       - junit:
           results: tests.xml

--- a/jobs/github/scripts/goversion.sh
+++ b/jobs/github/scripts/goversion.sh
@@ -1,53 +1,8 @@
 #!/bin/bash
 set -ex
 
-# Expected to be used within a ci-run job, but can be run stand alone.
-# Needs the following env-vars set:
-# $repo: the repo to build, i.e. juju/juju
-# $pr_id: the PR number to build, i.e. 9043
-
-tmpname=$(mktemp /tmp/pr.XXXXX)
-
-mergeable_state="unknown"
-retries=0
-while [ "$mergeable_state" = "unknown" ]; do
-    curl -s "https://api.github.com/repos/$ghprbGhRepository/pulls/$ghprbPullId" > "$tmpname"
-    if [ -f "$tmpname" ]; then
-        mergeable_state=$(jq -r ".\"mergeable_state\"" "$tmpname")
-    fi
-    
-    # If the mergeable state is null, then handle that and ensure the mergeable
-    # state is set back to unknown.
-    if [ "$mergeable_state" = "null" ]; then
-        mergeable_state="unknown"
-    fi
-
-    if [ "$mergeable_state" = "draft" ];  then
-        echo "PR $ghprbPullId is in a draft state"
-        exit 1
-    fi
-
-    if [ "$mergeable_state" = "unknown" ]; then
-        retries=$((retries+1))
-        if [ $retries -gt 10 ]; then
-            echo "https://github.com/$ghprbGhRepository/pull/$ghprbPullId failed to compute merge"
-            exit 1
-        fi
-        echo `date --rfc-3339=seconds` "Waiting for GitHub to compute merge"
-        sleep 10
-    fi
-done
-
-mergeable=$(jq -r ".\"mergeable\"" "$tmpname")
-if [ "$mergeable" != "true" ]; then
-    echo "https://github.com/$ghprbGhRepository/pull/$ghprbPullId has merge conflicts"
-    exit 1
-fi
-
-merge_commit=$(jq -r ".\"merge_commit_sha\"" "$tmpname")
-
 set +e
-gomod=$(curl -fs "https://raw.githubusercontent.com/$ghprbGhRepository/$merge_commit/go.mod")
+gomod=$(curl -fs "https://raw.githubusercontent.com/$ghprbGhRepository/$MERGE_COMMIT/go.mod")
 rval=$?
 if [ $rval -ne 0 ]; then
   echo "GOVERSION=''" > "${WORKSPACE}/goversion"

--- a/jobs/github/scripts/merge-commit.sh
+++ b/jobs/github/scripts/merge-commit.sh
@@ -4,25 +4,17 @@ set -ex
 # Expected to be used within a ci-run job, but can be run stand alone.
 # Needs the following env-vars set:
 # $dest_dir: Destination to pull to, i.e. /home/user/go/src/github.com/juju/juju
-# $repo: the repo to build, i.e. juju/juju
-# $pr_id: the PR number to build, i.e. 9043
+# $ghprbGhRepository: the repo to build, i.e. juju/juju
+# $ghprbPullId: the PR number to build, i.e. 9043
 # $pr_commit: the commit sha of the pr to checkout, i.e. b66d8932d504d01a1ecebe0355afa7efe96cd45c
 # $target_branch: the target branch of the PR, to merge into. i.e. develop
 
-if [ -z "$dest_dir" ]; then
-    echo "No \$dest_dir set, unable to continue."
-    exit 1
-fi
-
-mkdir -p "$dest_dir"
-
-if [ -z "$MERGE_COMMIT" ]; then
 tmpname=$(mktemp /tmp/pr.XXXXX)
 
 mergeable_state="unknown"
 retries=0
 while [ "$mergeable_state" = "unknown" ]; do
-    curl -s "https://api.github.com/repos/$repo/pulls/$pr_id" > "$tmpname"
+    curl -s "https://api.github.com/repos/$ghprbGhRepository/pulls/$ghprbPullId" > "$tmpname"
     if [ -f "$tmpname" ]; then
         mergeable_state=$(jq -r ".\"mergeable_state\"" "$tmpname")
     fi
@@ -34,14 +26,14 @@ while [ "$mergeable_state" = "unknown" ]; do
     fi
 
     if [ "$mergeable_state" = "draft" ];  then
-        echo "PR $pr_id is in a draft state"
+        echo "PR $ghprbPullId is in a draft state"
         exit 1
     fi
 
     if [ "$mergeable_state" = "unknown" ]; then
         retries=$((retries+1))
         if [ $retries -gt 10 ]; then
-            echo "https://github.com/$repo/pull/$pr_id failed to compute merge"
+            echo "https://github.com/$ghprbGhRepository/pull/$ghprbPullId failed to compute merge"
             exit 1
         fi
         echo `date --rfc-3339=seconds` "Waiting for GitHub to compute merge"
@@ -51,23 +43,13 @@ done
 
 mergeable=$(jq -r ".\"mergeable\"" "$tmpname")
 if [ "$mergeable" != "true" ]; then
-    echo "https://github.com/$repo/pull/$pr_id has merge conflicts"
+    echo "https://github.com/$ghprbGhRepository/pull/$ghprbPullId has merge conflicts"
     exit 1
 fi
 
-MERGE_COMMIT=$(jq -r ".\"merge_commit_sha\"" "$tmpname")
-fi
+merge_commit=$(jq -r ".\"merge_commit_sha\"" "$tmpname")
 
-git init "$dest_dir"
-echo `date --rfc-3339=seconds` "Fetching branch"
+echo "MERGE_COMMIT=$merge_commit" > "${WORKSPACE}/merge-commit"
 
-cd "$dest_dir"
-
-git remote add origin "https://github.com/$repo.git"
-git config --local gc.auto 0
-git fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin "+$MERGE_COMMIT"":refs/remotes/pull/$pr_id/merge"
-git checkout --progress --force "refs/remotes/pull/$pr_id/merge"
-git --no-pager log -1
-
-echo `date --rfc-3339=seconds` "Fetched pseduo merge commit $MERGE_COMMIT"
+cat "${WORKSPACE}/merge-commit"
 exit 0

--- a/jobs/github/utils.yml
+++ b/jobs/github/utils.yml
@@ -45,3 +45,52 @@
     builders:
     - shell:
         !include-raw: "scripts/github-merge.sh"
+
+- builder:
+    name: 'resolve-merge-commit'
+    builders:
+    - shell:
+        !include-raw: "scripts/merge-commit.sh"
+    - inject:
+        properties-file: ${WORKSPACE}/merge-commit
+
+- builder:
+    name: 'set-check-description'
+    builders:
+        - description-setter:
+            description: "PR=${ghprbPullLink} GOVERSION=${GOVERSION} MERGE_COMMIT=${MERGE_COMMIT}"
+
+- builder:
+    name: 'should-skip-juju-make-check'
+    builders:
+        - system-groovy:
+            command: |
+                import hudson.model.*
+                import jenkins.model.Jenkins
+                import org.jenkinsci.plugins.envinject.EnvInjectPluginAction
+
+                def pr = build.getEnvironment(listener).get("ghprbPullLink")
+                def goversion = build.getEnvironment(listener).get("GOVERSION")
+                def mergecommit = build.getEnvironment(listener).get("MERGE_COMMIT")
+                def b = Jenkins.getInstance().getItem("github-make-check-juju").getLastBuild()
+                def limit = 100
+                while (b != null && limit > 0) {
+                    def current = b
+                    limit = limit - 1
+                    b = b.getPreviousBuild()
+                    if (current.result == null) {
+                        continue
+                    }
+                    if (current.result != Result.SUCCESS) {
+                        continue
+                    }
+                    def vars = current.buildVariableResolver
+                    println "${vars.resolve("ghprbPullLink")} ${vars.resolve("GOVERSION")} ${vars.resolve("MERGE_COMMIT")}"
+                    if (vars.resolve("ghprbPullLink").equals(pr) &&
+                        vars.resolve("GOVERSION").equals(goversion) &&
+                        vars.resolve("MERGE_COMMIT").equals(mergecommit)) {
+                        println "Found previous successful build ${build.getAbsoluteUrl()} with the same parameters"
+                        build.getAction(EnvInjectPluginAction.class).overrideAll([SKIP_CHECK: '1'])
+                        break
+                    }
+                }


### PR DESCRIPTION
Added support for quick merges by skipping the check job if it has already run.

should-skip-juju-make-check builder uses a groovy script to look back at old make check builds. If it finds one that has succeeded, has the same pr url, same go version and same pseudo merge commit sha, then it sets the env var SKIP_CHECK.