### PR TITLE
Fix artifact publishing.

### DIFF
--- a/jobs/ci-run/integration/integrationtests.yml
+++ b/jobs/ci-run/integration/integrationtests.yml
@@ -341,7 +341,7 @@
     name: 'integration-artifacts'
     publishers:
         - archive:
-            artifacts: "${WORKSPACE}/artifacts/output.tar.gz"
+            artifacts: "artifacts/output.tar.gz"
             allow-empty: true
             only-if-success: false
             fingerprint: false


### PR DESCRIPTION
Publishing artifacts are relative to the workspace directory.