### PR TITLE
Ensure we correctly detect cgo

### DIFF
--- a/jobs/ci-run/scripts/snippet_make-release-build.sh
+++ b/jobs/ci-run/scripts/snippet_make-release-build.sh
@@ -9,8 +9,12 @@ echo AGENT_PACKAGE_PLATFORMS=${{AGENT_PACKAGE_PLATFORMS}}
 echo BUILD_TAGS=${{BUILD_TAGS:-}}
 
 cd ${{JUJU_SRC_PATH}}
-build_type=$(grep "go-agent-build-no-cgo" Makefile >/dev/null && echo "no-cgo" || echo "")
-if [ $build_type = "no-cgo" ]; then
+
+# Feature detection for cgo. We should really have a better way to do this.
+# Note: we can't detect CGO in the Makefile, as we've got references to cgo
+# inside the Makefile.
+build_type=$(grep "go-agent-build-no-cgo" Makefile >/dev/null && echo "cgo" || echo "")
+if [ $build_type = "cgo" ]; then
     GOOS=$(echo $AGENT_PACKAGE_PLATFORMS | cut -d/ -f 1) \
     GOARCH=$(echo $AGENT_PACKAGE_PLATFORMS | cut -d/ -f 2 | sed "s/ppc64el/ppc64le/") \
         make -j`nproc` go-build BUILD_TAGS="${{BUILD_TAGS:-}}"


### PR DESCRIPTION
The following detects the cgo check by looking for cgo rather than no-cgo.