### PR TITLE
Prevent accidental generating of tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,10 @@ dot-graph:
 
 gen-wire-tests:
 	$(eval config := "./tools/gen-wire-tests/juju.config")
-	@go run ./tools/gen-wire-tests/main.go\
-		"${JUJU_REPO_PATH}/tests/suites"\
-		"./jobs/ci-run/integration/gen"\
+	@go run ./tools/gen-wire-tests/main.go \
+		"${JUJU_REPO_PATH}/tests/suites" \
+		"./jobs/ci-run/integration/gen" \
+		"3.3" \
 		<"${config}"
 
 .PHONY: clean

--- a/jobs/ci-run/integration/gen/test-cli.yml
+++ b/jobs/ci-run/integration/gen/test-cli.yml
@@ -40,6 +40,8 @@
           current-parameters: true
         - name: 'test-cli-test-model-config-lxd'
           current-parameters: true
+        - name: 'test-cli-test-model-constraints-lxd'
+          current-parameters: true
         - name: 'test-cli-test-model-defaults-lxd'
           current-parameters: true
         - name: 'test-cli-test-unregister-lxd'
@@ -112,7 +114,7 @@
             test_name: 'cli'
             setup_steps: ''
             task_name: 'test_block_commands'
-            skip_tasks: 'test_display_clouds,test_local_charms,test_model_config,test_model_defaults,test_unregister'
+            skip_tasks: 'test_display_clouds,test_local_charms,test_model_config,test_model_constraints,test_model_defaults,test_unregister'
     publishers:
       - integration-artifacts
 
@@ -183,7 +185,7 @@
             test_name: 'cli'
             setup_steps: ''
             task_name: 'test_display_clouds'
-            skip_tasks: 'test_block_commands,test_local_charms,test_model_config,test_model_defaults,test_unregister'
+            skip_tasks: 'test_block_commands,test_local_charms,test_model_config,test_model_constraints,test_model_defaults,test_unregister'
     publishers:
       - integration-artifacts
 
@@ -254,7 +256,7 @@
             test_name: 'cli'
             setup_steps: ''
             task_name: 'test_local_charms'
-            skip_tasks: 'test_block_commands,test_display_clouds,test_model_config,test_model_defaults,test_unregister'
+            skip_tasks: 'test_block_commands,test_display_clouds,test_model_config,test_model_constraints,test_model_defaults,test_unregister'
     publishers:
       - integration-artifacts
 
@@ -325,7 +327,78 @@
             test_name: 'cli'
             setup_steps: ''
             task_name: 'test_model_config'
-            skip_tasks: 'test_block_commands,test_display_clouds,test_local_charms,test_model_defaults,test_unregister'
+            skip_tasks: 'test_block_commands,test_display_clouds,test_local_charms,test_model_constraints,test_model_defaults,test_unregister'
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-cli-test-model-constraints-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test test_model_constraints in cli suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - wait-for-cloud-init
+      - prepare-integration-test
+      - run-integration-test:
+            test_name: 'cli'
+            setup_steps: ''
+            task_name: 'test_model_constraints'
+            skip_tasks: 'test_block_commands,test_display_clouds,test_local_charms,test_model_config,test_model_defaults,test_unregister'
     publishers:
       - integration-artifacts
 
@@ -396,7 +469,7 @@
             test_name: 'cli'
             setup_steps: ''
             task_name: 'test_model_defaults'
-            skip_tasks: 'test_block_commands,test_display_clouds,test_local_charms,test_model_config,test_unregister'
+            skip_tasks: 'test_block_commands,test_display_clouds,test_local_charms,test_model_config,test_model_constraints,test_unregister'
     publishers:
       - integration-artifacts
 
@@ -467,6 +540,6 @@
             test_name: 'cli'
             setup_steps: ''
             task_name: 'test_unregister'
-            skip_tasks: 'test_block_commands,test_display_clouds,test_local_charms,test_model_config,test_model_defaults'
+            skip_tasks: 'test_block_commands,test_display_clouds,test_local_charms,test_model_config,test_model_constraints,test_model_defaults'
     publishers:
       - integration-artifacts

--- a/jobs/ci-run/integration/gen/test-controller.yml
+++ b/jobs/ci-run/integration/gen/test-controller.yml
@@ -36,6 +36,10 @@
           current-parameters: true
         - name: 'test-controller-test-enable-ha-lxd'
           current-parameters: true
+        - name: 'test-controller-test-metrics-aws'
+          current-parameters: true
+        - name: 'test-controller-test-metrics-lxd'
+          current-parameters: true
         - name: 'test-controller-test-mongo-memory-profile-aws'
           current-parameters: true
         - name: 'test-controller-test-mongo-memory-profile-lxd'
@@ -116,7 +120,7 @@
             test_name: 'controller'
             setup_steps: ''
             task_name: 'test_enable_ha'
-            skip_tasks: 'test_mongo_memory_profile,test_query_tracing'
+            skip_tasks: 'test_metrics,test_mongo_memory_profile,test_query_tracing'
     publishers:
       - integration-artifacts
 
@@ -187,7 +191,153 @@
             test_name: 'controller'
             setup_steps: ''
             task_name: 'test_enable_ha'
-            skip_tasks: 'test_mongo_memory_profile,test_query_tracing'
+            skip_tasks: 'test_metrics,test_mongo_memory_profile,test_query_tracing'
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-controller-test-metrics-aws
+    node: ephemeral-focal-small-amd64
+    description: |-
+      Test test_metrics in controller suite on aws
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'aws'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'ec2'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - wait-for-cloud-init
+      - prepare-integration-test
+      - run-integration-test:
+            test_name: 'controller'
+            setup_steps: ''
+            task_name: 'test_metrics'
+            skip_tasks: 'test_enable_ha,test_mongo_memory_profile,test_query_tracing'
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-controller-test-metrics-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test test_metrics in controller suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - wait-for-cloud-init
+      - prepare-integration-test
+      - run-integration-test:
+            test_name: 'controller'
+            setup_steps: ''
+            task_name: 'test_metrics'
+            skip_tasks: 'test_enable_ha,test_mongo_memory_profile,test_query_tracing'
     publishers:
       - integration-artifacts
 
@@ -262,7 +412,7 @@
             test_name: 'controller'
             setup_steps: ''
             task_name: 'test_mongo_memory_profile'
-            skip_tasks: 'test_enable_ha,test_query_tracing'
+            skip_tasks: 'test_enable_ha,test_metrics,test_query_tracing'
     publishers:
       - integration-artifacts
 
@@ -333,7 +483,7 @@
             test_name: 'controller'
             setup_steps: ''
             task_name: 'test_mongo_memory_profile'
-            skip_tasks: 'test_enable_ha,test_query_tracing'
+            skip_tasks: 'test_enable_ha,test_metrics,test_query_tracing'
     publishers:
       - integration-artifacts
 
@@ -414,7 +564,7 @@
                   test_name: 'controller'
                   setup_steps: ''
                   task_name: 'test_query_tracing'
-                  skip_tasks: 'test_enable_ha,test_mongo_memory_profile'
+                  skip_tasks: 'test_enable_ha,test_metrics,test_mongo_memory_profile'
     publishers:
       - integration-artifacts
 
@@ -491,6 +641,6 @@
                   test_name: 'controller'
                   setup_steps: ''
                   task_name: 'test_query_tracing'
-                  skip_tasks: 'test_enable_ha,test_mongo_memory_profile'
+                  skip_tasks: 'test_enable_ha,test_metrics,test_mongo_memory_profile'
     publishers:
       - integration-artifacts

--- a/jobs/ci-run/integration/gen/test-credential.yml
+++ b/jobs/ci-run/integration/gen/test-credential.yml
@@ -36,12 +36,16 @@
           current-parameters: true
         - name: 'test-credential-test-add-remove-credential-lxd'
           current-parameters: true
+        - name: 'test-credential-test-controller-credentials-aws'
+          current-parameters: true
+        - name: 'test-credential-test-controller-credentials-lxd'
+          current-parameters: true
 
 - job:
     name: test-credential-test-add-remove-credential-aws
     node: ephemeral-focal-small-amd64
     description: |-
-      Test credential suite on aws
+      Test test_add_remove_credential in credential suite on aws
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -107,8 +111,8 @@
       - run-integration-test:
             test_name: 'credential'
             setup_steps: ''
-            task_name: ''
-            skip_tasks: ''
+            task_name: 'test_add_remove_credential'
+            skip_tasks: 'test_controller_credentials'
     publishers:
       - integration-artifacts
 
@@ -116,7 +120,7 @@
     name: test-credential-test-add-remove-credential-lxd
     node: ephemeral-focal-8c-32g-amd64
     description: |-
-      Test credential suite on lxd
+      Test test_add_remove_credential in credential suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -178,7 +182,153 @@
       - run-integration-test:
             test_name: 'credential'
             setup_steps: ''
-            task_name: ''
-            skip_tasks: ''
+            task_name: 'test_add_remove_credential'
+            skip_tasks: 'test_controller_credentials'
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-credential-test-controller-credentials-aws
+    node: ephemeral-focal-small-amd64
+    description: |-
+      Test test_controller_credentials in credential suite on aws
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'aws'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'ec2'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - wait-for-cloud-init
+      - prepare-integration-test
+      - run-integration-test:
+            test_name: 'credential'
+            setup_steps: ''
+            task_name: 'test_controller_credentials'
+            skip_tasks: 'test_add_remove_credential'
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-credential-test-controller-credentials-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test test_controller_credentials in credential suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - wait-for-cloud-init
+      - prepare-integration-test
+      - run-integration-test:
+            test_name: 'credential'
+            setup_steps: ''
+            task_name: 'test_controller_credentials'
+            skip_tasks: 'test_add_remove_credential'
     publishers:
       - integration-artifacts

--- a/jobs/ci-run/integration/gen/test-secrets_iaas.yml
+++ b/jobs/ci-run/integration/gen/test-secrets_iaas.yml
@@ -34,6 +34,8 @@
         projects:
         - name: 'test-secrets_iaas-test-secret-drain-lxd'
           current-parameters: true
+        - name: 'test-secrets_iaas-test-secrets-cmr-lxd'
+          current-parameters: true
         - name: 'test-secrets_iaas-test-secrets-juju-lxd'
           current-parameters: true
         - name: 'test-secrets_iaas-test-secrets-vault-lxd'
@@ -106,7 +108,78 @@
             test_name: 'secrets_iaas'
             setup_steps: ''
             task_name: 'test_secret_drain'
-            skip_tasks: 'test_secrets_juju,test_secrets_vault'
+            skip_tasks: 'test_secrets_cmr,test_secrets_juju,test_secrets_vault'
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-secrets_iaas-test-secrets-cmr-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test test_secrets_cmr in secrets_iaas suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - wait-for-cloud-init
+      - prepare-integration-test
+      - run-integration-test:
+            test_name: 'secrets_iaas'
+            setup_steps: ''
+            task_name: 'test_secrets_cmr'
+            skip_tasks: 'test_secret_drain,test_secrets_juju,test_secrets_vault'
     publishers:
       - integration-artifacts
 
@@ -177,7 +250,7 @@
             test_name: 'secrets_iaas'
             setup_steps: ''
             task_name: 'test_secrets_juju'
-            skip_tasks: 'test_secret_drain,test_secrets_vault'
+            skip_tasks: 'test_secret_drain,test_secrets_cmr,test_secrets_vault'
     publishers:
       - integration-artifacts
 
@@ -248,6 +321,6 @@
             test_name: 'secrets_iaas'
             setup_steps: ''
             task_name: 'test_secrets_vault'
-            skip_tasks: 'test_secret_drain,test_secrets_juju'
+            skip_tasks: 'test_secret_drain,test_secrets_cmr,test_secrets_juju'
     publishers:
       - integration-artifacts

--- a/jobs/ci-run/integration/gen/test-user.yml
+++ b/jobs/ci-run/integration/gen/test-user.yml
@@ -36,6 +36,10 @@
           current-parameters: true
         - name: 'test-user-test-user-manage-lxd'
           current-parameters: true
+        - name: 'test-user-test-user-register-aws'
+          current-parameters: true
+        - name: 'test-user-test-user-register-lxd'
+          current-parameters: true
 
 - job:
     name: test-user-test-user-login-password-aws
@@ -108,7 +112,7 @@
             test_name: 'user'
             setup_steps: ''
             task_name: 'test_user_login_password'
-            skip_tasks: 'test_user_manage'
+            skip_tasks: 'test_user_manage,test_user_register'
     publishers:
       - integration-artifacts
 
@@ -179,7 +183,7 @@
             test_name: 'user'
             setup_steps: ''
             task_name: 'test_user_login_password'
-            skip_tasks: 'test_user_manage'
+            skip_tasks: 'test_user_manage,test_user_register'
     publishers:
       - integration-artifacts
 
@@ -254,7 +258,7 @@
             test_name: 'user'
             setup_steps: ''
             task_name: 'test_user_manage'
-            skip_tasks: 'test_user_login_password'
+            skip_tasks: 'test_user_login_password,test_user_register'
     publishers:
       - integration-artifacts
 
@@ -325,6 +329,152 @@
             test_name: 'user'
             setup_steps: ''
             task_name: 'test_user_manage'
-            skip_tasks: 'test_user_login_password'
+            skip_tasks: 'test_user_login_password,test_user_register'
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-user-test-user-register-aws
+    node: ephemeral-focal-small-amd64
+    description: |-
+      Test test_user_register in user suite on aws
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'aws'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'ec2'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - wait-for-cloud-init
+      - prepare-integration-test
+      - run-integration-test:
+            test_name: 'user'
+            setup_steps: ''
+            task_name: 'test_user_register'
+            skip_tasks: 'test_user_login_password,test_user_manage'
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-user-test-user-register-lxd
+    node: ephemeral-focal-8c-32g-amd64
+    description: |-
+      Test test_user_register in user suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{7}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'lxd'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    - string:
+        default: jujuqabot
+        description: "Operator docker image account name."
+        name: OPERATOR_IMAGE_ACCOUNT
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - wait-for-cloud-init
+      - prepare-integration-test
+      - run-integration-test:
+            test_name: 'user'
+            setup_steps: ''
+            task_name: 'test_user_register'
+            skip_tasks: 'test_user_login_password,test_user_manage'
     publishers:
       - integration-artifacts

--- a/tests/suites/static_analysis/deadcode/main.go
+++ b/tests/suites/static_analysis/deadcode/main.go
@@ -173,7 +173,11 @@ func extractMultiJobNames(multijob map[interface{}]interface{}) []string {
 	var names []string
 	for k, v := range multijob {
 		if k == "projects" {
-			for _, v := range v.([]interface{}) {
+			slice, ok := v.([]interface{})
+			if !ok {
+				continue
+			}
+			for _, v := range slice {
 				m := v.(map[interface{}]interface{})
 				if name, ok := m["name"]; ok {
 					names = append(names, name.(string))

--- a/tools/gen-wire-tests/juju.config
+++ b/tools/gen-wire-tests/juju.config
@@ -53,6 +53,7 @@ folders:
     - static_analysis
     - ck
     - kubeflow
+    - metrics
   skip-lxd:
     - caasadmission
     - coslite


### PR DESCRIPTION
The following just forces the generation of the integration branches to be based on 3.3 juju version.