### PR TITLE
[JUJU-4242] Extend timeout of cmr tests

### DIFF
--- a/jobs/ci-run/integration/gen/test-cmr.yml
+++ b/jobs/ci-run/integration/gen/test-cmr.yml
@@ -98,7 +98,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 45
           fail: true
           type: absolute
     builders:
@@ -169,7 +169,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 45
           fail: true
           type: absolute
     builders:

--- a/tools/gen-wire-tests/juju.config
+++ b/tools/gen-wire-tests/juju.config
@@ -12,6 +12,8 @@ folders:
       test_deploy_magma: 90
     deploy:
       test_deploy_bundles: 50
+    cmr:
+      test_offer_consume: 45
   unstable:
     deploy:
       lxd:


### PR DESCRIPTION
Test runs such as:
https://jenkins.juju.canonical.com/job/test-cmr-test-offer-consume-aws/805

Seem to be failing because they time out just before the controllers are able to be fully destroyed. Extend the timeout for thsi job slightly