### PR TITLE
Fix docker repo references missing domain.

### DIFF
--- a/jobs/ci-run/build/buildjuju.yml
+++ b/jobs/ci-run/build/buildjuju.yml
@@ -162,9 +162,9 @@
       - choice:
           name: OPERATOR_IMAGE_ACCOUNT
           choices:
-            - jujuqabot
-            - jujusolutions
-          default: "jujuqabot"
+            - docker.io/jujuqabot
+            - docker.io/jujusolutions
+          default: "docker.io/jujuqabot"
           description: "Operator docker image account name."
       - string:
           default: "linux/amd64 linux/arm64 linux/s390x linux/ppc64el"

--- a/jobs/ci-run/ci-run-master.yml
+++ b/jobs/ci-run/ci-run-master.yml
@@ -96,7 +96,7 @@
       - get-s3-source-payload
       - inject:
           properties-content: |-
-            OPERATOR_IMAGE_ACCOUNT=jujuqabot
+            OPERATOR_IMAGE_ACCOUNT=docker.io/jujuqabot
             PATH=/snap/bin:$PATH
             series=focal
       - get-build-details

--- a/jobs/ci-run/functional/amd64/iaas-controller-deploy-caas-charms.yaml
+++ b/jobs/ci-run/functional/amd64/iaas-controller-deploy-caas-charms.yaml
@@ -18,7 +18,7 @@
           description: "Specify K8s cloud provider to use."
           name: CAAS_PROVIDER
       - string:
-          default: jujuqabot
+          default: docker.io/jujuqabot
           description: "Operator docker image account name."
           name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -58,7 +58,7 @@
           description: "Specify K8s cloud provider to use."
           name: CAAS_PROVIDER
       - string:
-          default: "jujuqabot"
+          default: "docker.io/jujuqabot"
           description: "Operator docker image account name."
           name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/functional/amd64/k8s-controller-deploy-caas-charms.yaml
+++ b/jobs/ci-run/functional/amd64/k8s-controller-deploy-caas-charms.yaml
@@ -17,7 +17,7 @@
           description: "Specify K8s cloud provider to use."
           name: CAAS_PROVIDER
       - string:
-          default: jujuqabot
+          default: docker.io/jujuqabot
           description: "Operator docker image account name."
           name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -60,7 +60,7 @@
           description: "Specify K8s cloud provider to use."
           name: CAAS_PROVIDER
       - string:
-          default: jujuqabot
+          default: docker.io/jujuqabot
           description: "Operator docker image account name."
           name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -104,7 +104,7 @@
           description: "Specify K8s cloud provider to use."
           name: CAAS_PROVIDER
       - string:
-          default: jujuqabot
+          default: docker.io/jujuqabot
           description: "Operator docker image account name."
           name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/functional/amd64/k8s-controller-deploy-kubeflow.yml
+++ b/jobs/ci-run/functional/amd64/k8s-controller-deploy-kubeflow.yml
@@ -22,7 +22,7 @@
         description: "Specify K8s cloud provider to use."
         name: CAAS_PROVIDER
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     - string:

--- a/jobs/ci-run/integration/common/registry-setup.sh
+++ b/jobs/ci-run/integration/common/registry-setup.sh
@@ -27,15 +27,15 @@ echo "${ECR_TOKEN}" | docker login -u AWS --password-stdin "${DOCKER_REGISTRY}"
 DOCKER_USERNAME=${OPERATOR_IMAGE_ACCOUNT} make -C "${JUJU_SRC_PATH}" push-release-operator-image
 
 # Copy juju-db from docker
-docker pull "jujusolutions/juju-db:${JUJU_DB_TAG}"
-docker tag "jujusolutions/juju-db:${JUJU_DB_TAG}" "${OPERATOR_IMAGE_ACCOUNT}/juju-db:${JUJU_DB_TAG}"
+docker pull "docker.io/jujusolutions/juju-db:${JUJU_DB_TAG}"
+docker tag "docker.io/jujusolutions/juju-db:${JUJU_DB_TAG}" "${OPERATOR_IMAGE_ACCOUNT}/juju-db:${JUJU_DB_TAG}"
 docker push "${OPERATOR_IMAGE_ACCOUNT}/juju-db:${JUJU_DB_TAG}"
 
 # Copy LTS charm bases from docker
 BASES=(18.04 20.04 22.04)
 for BASE in "${BASES[@]}" ; do
-  docker pull "jujusolutions/charm-base:ubuntu-${BASE}"
-  docker tag "jujusolutions/charm-base:ubuntu-${BASE}" "${OPERATOR_IMAGE_ACCOUNT}/charm-base:ubuntu-${BASE}"
+  docker pull "docker.io/jujusolutions/charm-base:ubuntu-${BASE}"
+  docker tag "docker.io/jujusolutions/charm-base:ubuntu-${BASE}" "${OPERATOR_IMAGE_ACCOUNT}/charm-base:ubuntu-${BASE}"
   docker push "${OPERATOR_IMAGE_ACCOUNT}/charm-base:ubuntu-${BASE}"
 done
 

--- a/jobs/ci-run/integration/gen/test-agents.yml
+++ b/jobs/ci-run/integration/gen/test-agents.yml
@@ -92,7 +92,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -163,7 +163,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-appdata.yml
+++ b/jobs/ci-run/integration/gen/test-appdata.yml
@@ -92,7 +92,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -163,7 +163,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-backup.yml
+++ b/jobs/ci-run/integration/gen/test-backup.yml
@@ -92,7 +92,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -163,7 +163,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-bootstrap.yml
+++ b/jobs/ci-run/integration/gen/test-bootstrap.yml
@@ -86,7 +86,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-branches.yml
+++ b/jobs/ci-run/integration/gen/test-branches.yml
@@ -96,7 +96,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -167,7 +167,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -242,7 +242,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -313,7 +313,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-caasadmission.yml
+++ b/jobs/ci-run/integration/gen/test-caasadmission.yml
@@ -90,7 +90,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -161,7 +161,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -232,7 +232,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-charmhub.yml
+++ b/jobs/ci-run/integration/gen/test-charmhub.yml
@@ -100,7 +100,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -171,7 +171,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -246,7 +246,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -317,7 +317,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -392,7 +392,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -463,7 +463,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-cli.yml
+++ b/jobs/ci-run/integration/gen/test-cli.yml
@@ -98,7 +98,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -169,7 +169,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -240,7 +240,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -311,7 +311,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -382,7 +382,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -453,7 +453,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -524,7 +524,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-cmr.yml
+++ b/jobs/ci-run/integration/gen/test-cmr.yml
@@ -92,7 +92,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -163,7 +163,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-constraints.yml
+++ b/jobs/ci-run/integration/gen/test-constraints.yml
@@ -92,7 +92,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -163,7 +163,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-controller.yml
+++ b/jobs/ci-run/integration/gen/test-controller.yml
@@ -104,7 +104,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -175,7 +175,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -250,7 +250,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -321,7 +321,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -396,7 +396,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -467,7 +467,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -542,7 +542,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -619,7 +619,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-coslite.yml
+++ b/jobs/ci-run/integration/gen/test-coslite.yml
@@ -86,7 +86,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-credential.yml
+++ b/jobs/ci-run/integration/gen/test-credential.yml
@@ -96,7 +96,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -167,7 +167,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -242,7 +242,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -313,7 +313,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-dashboard.yml
+++ b/jobs/ci-run/integration/gen/test-dashboard.yml
@@ -98,7 +98,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -173,7 +173,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -248,7 +248,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -319,7 +319,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -390,7 +390,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-deploy.yml
+++ b/jobs/ci-run/integration/gen/test-deploy.yml
@@ -104,7 +104,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -175,7 +175,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -250,7 +250,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -321,7 +321,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -396,7 +396,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -467,7 +467,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -542,7 +542,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -613,7 +613,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -688,7 +688,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -759,7 +759,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -834,7 +834,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -905,7 +905,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-deploy_aks.yml
+++ b/jobs/ci-run/integration/gen/test-deploy_aks.yml
@@ -90,7 +90,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-deploy_caas.yml
+++ b/jobs/ci-run/integration/gen/test-deploy_caas.yml
@@ -86,7 +86,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-firewall.yml
+++ b/jobs/ci-run/integration/gen/test-firewall.yml
@@ -94,7 +94,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -169,7 +169,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -244,7 +244,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-hooks.yml
+++ b/jobs/ci-run/integration/gen/test-hooks.yml
@@ -96,7 +96,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -167,7 +167,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -242,7 +242,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -313,7 +313,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-hooktools.yml
+++ b/jobs/ci-run/integration/gen/test-hooktools.yml
@@ -92,7 +92,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -163,7 +163,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-machine.yml
+++ b/jobs/ci-run/integration/gen/test-machine.yml
@@ -92,7 +92,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -163,7 +163,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-magma.yml
+++ b/jobs/ci-run/integration/gen/test-magma.yml
@@ -86,7 +86,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-manual.yml
+++ b/jobs/ci-run/integration/gen/test-manual.yml
@@ -96,7 +96,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -167,7 +167,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -242,7 +242,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -313,7 +313,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-model.yml
+++ b/jobs/ci-run/integration/gen/test-model.yml
@@ -112,7 +112,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -187,7 +187,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -258,7 +258,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -333,7 +333,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -408,7 +408,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -479,7 +479,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -554,7 +554,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -629,7 +629,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -700,7 +700,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -775,7 +775,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -850,7 +850,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -921,7 +921,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -996,7 +996,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -1071,7 +1071,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -1142,7 +1142,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -1217,7 +1217,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -1292,7 +1292,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -1363,7 +1363,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -1438,7 +1438,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -1513,7 +1513,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -1584,7 +1584,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -1659,7 +1659,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -1734,7 +1734,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -1805,7 +1805,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -1880,7 +1880,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -1955,7 +1955,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -2026,7 +2026,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-network.yml
+++ b/jobs/ci-run/integration/gen/test-network.yml
@@ -96,7 +96,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -171,7 +171,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -246,7 +246,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -317,7 +317,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-refresh.yml
+++ b/jobs/ci-run/integration/gen/test-refresh.yml
@@ -96,7 +96,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -167,7 +167,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -242,7 +242,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -313,7 +313,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-relations.yml
+++ b/jobs/ci-run/integration/gen/test-relations.yml
@@ -100,7 +100,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -171,7 +171,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -246,7 +246,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -317,7 +317,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -392,7 +392,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -463,7 +463,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-resources.yml
+++ b/jobs/ci-run/integration/gen/test-resources.yml
@@ -96,7 +96,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -167,7 +167,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -242,7 +242,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -313,7 +313,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-secrets_iaas.yml
+++ b/jobs/ci-run/integration/gen/test-secrets_iaas.yml
@@ -92,7 +92,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -163,7 +163,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -234,7 +234,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -305,7 +305,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-secrets_k8s.yml
+++ b/jobs/ci-run/integration/gen/test-secrets_k8s.yml
@@ -88,7 +88,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -159,7 +159,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-sidecar.yml
+++ b/jobs/ci-run/integration/gen/test-sidecar.yml
@@ -88,7 +88,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -159,7 +159,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-smoke.yml
+++ b/jobs/ci-run/integration/gen/test-smoke.yml
@@ -96,7 +96,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -167,7 +167,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -242,7 +242,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -313,7 +313,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-spaces_ec2.yml
+++ b/jobs/ci-run/integration/gen/test-spaces_ec2.yml
@@ -94,7 +94,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -169,7 +169,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -244,7 +244,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-storage.yml
+++ b/jobs/ci-run/integration/gen/test-storage.yml
@@ -92,7 +92,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -167,7 +167,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-unit.yml
+++ b/jobs/ci-run/integration/gen/test-unit.yml
@@ -92,7 +92,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -163,7 +163,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-upgrade.yml
+++ b/jobs/ci-run/integration/gen/test-upgrade.yml
@@ -86,7 +86,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-upgrade_series.yml
+++ b/jobs/ci-run/integration/gen/test-upgrade_series.yml
@@ -86,7 +86,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/gen/test-user.yml
+++ b/jobs/ci-run/integration/gen/test-user.yml
@@ -96,7 +96,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -167,7 +167,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -242,7 +242,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -313,7 +313,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -388,7 +388,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:
@@ -459,7 +459,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/man/test-ck.yml
+++ b/jobs/ci-run/integration/man/test-ck.yml
@@ -37,7 +37,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/jobs/ci-run/integration/man/test-kubeflow.yml
+++ b/jobs/ci-run/integration/man/test-kubeflow.yml
@@ -51,7 +51,7 @@
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:

--- a/tools/gen-wire-tests/main.go
+++ b/tools/gen-wire-tests/main.go
@@ -536,7 +536,7 @@ const Template = `
         description: 'Ubuntu series to use when bootstrapping Juju'
         name: BOOTSTRAP_SERIES
     - string:
-        default: jujuqabot
+        default: docker.io/jujuqabot
         description: "Operator docker image account name."
         name: OPERATOR_IMAGE_ACCOUNT
     wrappers:


### PR DESCRIPTION
Prefixes all docker repos with docker.io to address new requirement that docker image references be fully qualified with a domain.

https://github.com/juju/juju/pull/16367