### PR TITLE
Start to prefix parameters with `PARAM_`

### DIFF
--- a/jobs/ci-run/build/buildjuju.yml
+++ b/jobs/ci-run/build/buildjuju.yml
@@ -160,7 +160,7 @@
           description: 'Go version used for build.'
           name: GOVERSION
       - choice:
-          name: OPERATOR_IMAGE_ACCOUNT
+          name: PARAM_OPERATOR_IMAGE_ACCOUNT
           choices:
             - docker.io/jujuqabot
             - docker.io/jujusolutions
@@ -183,7 +183,7 @@
           set -eu
 
           touch build.properties
-          echo "DOCKER_USERNAME=${OPERATOR_IMAGE_ACCOUNT}" >> build.properties
+          echo "DOCKER_USERNAME=${PARAM_OPERATOR_IMAGE_ACCOUNT}" >> build.properties
 
           cat build.properties
       - inject:

--- a/jobs/ci-run/functional/amd64/iaas-controller-deploy-caas-charms.yaml
+++ b/jobs/ci-run/functional/amd64/iaas-controller-deploy-caas-charms.yaml
@@ -20,7 +20,7 @@
       - string:
           default: docker.io/jujuqabot
           description: "Operator docker image account name."
-          name: OPERATOR_IMAGE_ACCOUNT
+          name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - cirun-test-stuck-timeout
     builders:
@@ -32,7 +32,7 @@
 
           ENV=parallel-lxd
           timeout -s INT 50m ${TESTS_DIR}/assess_caas_deploy_charms.py $ENV $JUJU_BIN $WORKSPACE/artifacts \
-          $JOB_NAME --caas-image-repo=${OPERATOR_IMAGE_ACCOUNT} \
+          $JOB_NAME --caas-image-repo=${PARAM_OPERATOR_IMAGE_ACCOUNT} \
           --caas-provider=${CAAS_PROVIDER}
     publishers:
       - artifact-results
@@ -60,7 +60,7 @@
       - string:
           default: "docker.io/jujuqabot"
           description: "Operator docker image account name."
-          name: OPERATOR_IMAGE_ACCOUNT
+          name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - cirun-test-stuck-timeout
     builders:
@@ -72,7 +72,7 @@
 
           ENV=parallel-lxd
           timeout -s INT 50m ${TESTS_DIR}/assess_caas_deploy_charms.py $ENV $JUJU_BIN $WORKSPACE/artifacts \
-          $JOB_NAME --caas-image-repo=${OPERATOR_IMAGE_ACCOUNT} \
+          $JOB_NAME --caas-image-repo=${PARAM_OPERATOR_IMAGE_ACCOUNT} \
           --caas-provider=${CAAS_PROVIDER}
     publishers:
       - artifact-results

--- a/jobs/ci-run/functional/amd64/k8s-controller-deploy-caas-charms.yaml
+++ b/jobs/ci-run/functional/amd64/k8s-controller-deploy-caas-charms.yaml
@@ -19,7 +19,7 @@
       - string:
           default: docker.io/jujuqabot
           description: "Operator docker image account name."
-          name: OPERATOR_IMAGE_ACCOUNT
+          name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - cirun-test-stuck-timeout
     builders:
@@ -35,7 +35,7 @@
 
           ENV=gke
           timeout -s INT 50m ${TESTS_DIR}/assess_caas_deploy_charms.py $ENV $JUJU_BIN $WORKSPACE/artifacts \
-          $JOB_NAME --caas-image-repo=${OPERATOR_IMAGE_ACCOUNT} \
+          $JOB_NAME --caas-image-repo=${PARAM_OPERATOR_IMAGE_ACCOUNT} \
           --caas-provider=${CAAS_PROVIDER} --k8s-controller --enable-rbac
     publishers:
       - artifact-results
@@ -62,7 +62,7 @@
       - string:
           default: docker.io/jujuqabot
           description: "Operator docker image account name."
-          name: OPERATOR_IMAGE_ACCOUNT
+          name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - cirun-test-stuck-timeout
     builders:
@@ -78,7 +78,7 @@
 
           ENV=aks
           timeout -s INT 50m ${TESTS_DIR}/assess_caas_deploy_charms.py $ENV $JUJU_BIN $WORKSPACE/artifacts \
-          $JOB_NAME --caas-image-repo=${OPERATOR_IMAGE_ACCOUNT} \
+          $JOB_NAME --caas-image-repo=${PARAM_OPERATOR_IMAGE_ACCOUNT} \
           --caas-provider=${CAAS_PROVIDER} --k8s-controller --enable-rbac
     publishers:
       - artifact-results
@@ -106,7 +106,7 @@
       - string:
           default: docker.io/jujuqabot
           description: "Operator docker image account name."
-          name: OPERATOR_IMAGE_ACCOUNT
+          name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - cirun-test-stuck-timeout
     builders:
@@ -122,7 +122,7 @@
 
           ENV=eks
           timeout -s INT 50m ${TESTS_DIR}/assess_caas_deploy_charms.py $ENV $JUJU_BIN $WORKSPACE/artifacts \
-          $JOB_NAME --caas-image-repo=${OPERATOR_IMAGE_ACCOUNT} \
+          $JOB_NAME --caas-image-repo=${PARAM_OPERATOR_IMAGE_ACCOUNT} \
           --caas-provider=${CAAS_PROVIDER} --k8s-controller --enable-rbac
     publishers:
       - artifact-results

--- a/jobs/ci-run/functional/amd64/k8s-controller-deploy-kubeflow.yml
+++ b/jobs/ci-run/functional/amd64/k8s-controller-deploy-kubeflow.yml
@@ -24,7 +24,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     - string:
         default: full
         description: "Specify the kubeflow bundle version to deploy."
@@ -42,7 +42,7 @@
     builders:
     - wait-for-cloud-init
     - description-setter:
-        description: "${CAAS_PROVIDER}|bundle:${BUNDLE_VERSION}|build:${BUILD_CHARMS}|rbac:${ENABLE_RBAC}|${OPERATOR_IMAGE_ACCOUNT}"
+        description: "${CAAS_PROVIDER}|bundle:${BUNDLE_VERSION}|build:${BUILD_CHARMS}|rbac:${ENABLE_RBAC}|${PARAM_OPERATOR_IMAGE_ACCOUNT}"
     - prepare-functional-test-core:
         platform: "linux/${BUILD_ARCH}"
     - prepare-ephemeral-node-for-k8s-py-tests:
@@ -73,7 +73,7 @@
             params+=( '--enable-rbac' )
         fi
         timeout -s INT 90m $TESTS_DIR/assess_caas_deploy_kubeflow.py $ENV $JUJU_BIN $WORKSPACE/artifacts \
-        $JOB_NAME --caas-image-repo=$OPERATOR_IMAGE_ACCOUNT \
+        $JOB_NAME --caas-image-repo=$PARAM_OPERATOR_IMAGE_ACCOUNT \
         --caas-provider=$CAAS_PROVIDER --k8s-controller --bundle=$BUNDLE_VERSION ${params[@]}
     publishers:
     - artifact-results

--- a/jobs/ci-run/integration/builders.yaml
+++ b/jobs/ci-run/integration/builders.yaml
@@ -6,6 +6,8 @@
     - host-src-command:
         src_command:
           !include-raw: "common/registry-setup.sh"
+    - inject:
+          properties-file: build.properties
 
 - builder:
     name: 'prepare-integration-test'

--- a/jobs/ci-run/integration/common/registry-setup.sh
+++ b/jobs/ci-run/integration/common/registry-setup.sh
@@ -27,15 +27,15 @@ echo "${ECR_TOKEN}" | docker login -u AWS --password-stdin "${DOCKER_REGISTRY}"
 DOCKER_USERNAME=${OPERATOR_IMAGE_ACCOUNT} make -C "${JUJU_SRC_PATH}" push-release-operator-image
 
 # Copy juju-db from docker
-docker pull "docker.io/jujusolutions/juju-db:${JUJU_DB_TAG}"
-docker tag "docker.io/jujusolutions/juju-db:${JUJU_DB_TAG}" "${OPERATOR_IMAGE_ACCOUNT}/juju-db:${JUJU_DB_TAG}"
+docker pull "public.ecr.aws/juju/juju-db:${JUJU_DB_TAG}"
+docker tag "public.ecr.aws/juju/juju-db:${JUJU_DB_TAG}" "${OPERATOR_IMAGE_ACCOUNT}/juju-db:${JUJU_DB_TAG}"
 docker push "${OPERATOR_IMAGE_ACCOUNT}/juju-db:${JUJU_DB_TAG}"
 
 # Copy LTS charm bases from docker
 BASES=(18.04 20.04 22.04)
 for BASE in "${BASES[@]}" ; do
-  docker pull "docker.io/jujusolutions/charm-base:ubuntu-${BASE}"
-  docker tag "docker.io/jujusolutions/charm-base:ubuntu-${BASE}" "${OPERATOR_IMAGE_ACCOUNT}/charm-base:ubuntu-${BASE}"
+  docker pull "public.ecr.aws/juju/charm-base:ubuntu-${BASE}"
+  docker tag "public.ecr.aws/juju/charm-base:ubuntu-${BASE}" "${OPERATOR_IMAGE_ACCOUNT}/charm-base:ubuntu-${BASE}"
   docker push "${OPERATOR_IMAGE_ACCOUNT}/charm-base:ubuntu-${BASE}"
 done
 
@@ -50,5 +50,5 @@ OPERATOR_IMAGE_ACCOUNT=$(jq -r --null-input \
 OPERATOR_IMAGE_ACCOUNT_PATH="${WORKSPACE}/operator-image_account.json"
 echo "${OPERATOR_IMAGE_ACCOUNT}" > "${OPERATOR_IMAGE_ACCOUNT_PATH}"
 export OPERATOR_IMAGE_ACCOUNT=${OPERATOR_IMAGE_ACCOUNT_PATH}
-echo "OPERATOR_IMAGE_ACCOUNT=${OPERATOR_IMAGE_ACCOUNT_PATH}" >> "${WORKSPACE}/buildvars"
+echo "OPERATOR_IMAGE_ACCOUNT=${OPERATOR_IMAGE_ACCOUNT_PATH}" >> "${WORKSPACE}/build.properties"
 set -x

--- a/jobs/ci-run/integration/gen/test-agents.yml
+++ b/jobs/ci-run/integration/gen/test-agents.yml
@@ -94,7 +94,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -102,6 +102,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -165,7 +168,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -173,6 +176,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-appdata.yml
+++ b/jobs/ci-run/integration/gen/test-appdata.yml
@@ -94,7 +94,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -102,6 +102,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -165,7 +168,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -173,6 +176,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-backup.yml
+++ b/jobs/ci-run/integration/gen/test-backup.yml
@@ -94,7 +94,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -102,6 +102,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -165,7 +168,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -173,6 +176,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-bootstrap.yml
+++ b/jobs/ci-run/integration/gen/test-bootstrap.yml
@@ -88,7 +88,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -96,6 +96,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-branches.yml
+++ b/jobs/ci-run/integration/gen/test-branches.yml
@@ -98,7 +98,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -106,6 +106,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -169,7 +172,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -177,6 +180,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -244,7 +250,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -252,6 +258,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -315,7 +324,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -323,6 +332,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-caasadmission.yml
+++ b/jobs/ci-run/integration/gen/test-caasadmission.yml
@@ -92,7 +92,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -100,6 +100,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test-microk8s:
@@ -163,7 +166,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -171,6 +174,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test-microk8s:
@@ -234,7 +240,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -242,6 +248,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test-microk8s:

--- a/jobs/ci-run/integration/gen/test-charmhub.yml
+++ b/jobs/ci-run/integration/gen/test-charmhub.yml
@@ -102,7 +102,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -110,6 +110,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -173,7 +176,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -181,6 +184,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -248,7 +254,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -256,6 +262,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -319,7 +328,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -327,6 +336,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -394,7 +406,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -402,6 +414,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -465,7 +480,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -473,6 +488,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-cli.yml
+++ b/jobs/ci-run/integration/gen/test-cli.yml
@@ -100,7 +100,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -108,6 +108,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -171,7 +174,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -179,6 +182,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -242,7 +248,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -250,6 +256,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -313,7 +322,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -321,6 +330,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -384,7 +396,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -392,6 +404,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -455,7 +470,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -463,6 +478,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -526,7 +544,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -534,6 +552,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-cmr.yml
+++ b/jobs/ci-run/integration/gen/test-cmr.yml
@@ -94,7 +94,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -102,6 +102,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -165,7 +168,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -173,6 +176,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-constraints.yml
+++ b/jobs/ci-run/integration/gen/test-constraints.yml
@@ -94,7 +94,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -102,6 +102,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -165,7 +168,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -173,6 +176,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-controller.yml
+++ b/jobs/ci-run/integration/gen/test-controller.yml
@@ -106,7 +106,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -114,6 +114,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -177,7 +180,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -185,6 +188,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -252,7 +258,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -260,6 +266,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -323,7 +332,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -331,6 +340,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -398,7 +410,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -406,6 +418,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -469,7 +484,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -477,6 +492,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -544,7 +562,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -552,6 +570,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - conditional-step:
@@ -621,7 +642,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -629,6 +650,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - conditional-step:

--- a/jobs/ci-run/integration/gen/test-coslite.yml
+++ b/jobs/ci-run/integration/gen/test-coslite.yml
@@ -88,7 +88,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -96,6 +96,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test-microk8s:

--- a/jobs/ci-run/integration/gen/test-credential.yml
+++ b/jobs/ci-run/integration/gen/test-credential.yml
@@ -98,7 +98,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -106,6 +106,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -169,7 +172,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -177,6 +180,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -244,7 +250,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -252,6 +258,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -315,7 +324,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -323,6 +332,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-dashboard.yml
+++ b/jobs/ci-run/integration/gen/test-dashboard.yml
@@ -100,7 +100,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -108,6 +108,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -175,7 +178,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -183,6 +186,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -250,7 +256,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -258,6 +264,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -321,7 +330,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -329,6 +338,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -392,7 +404,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -400,6 +412,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test-microk8s:

--- a/jobs/ci-run/integration/gen/test-deploy.yml
+++ b/jobs/ci-run/integration/gen/test-deploy.yml
@@ -106,7 +106,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -114,6 +114,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -177,7 +180,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -185,6 +188,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -252,7 +258,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -260,6 +266,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -323,7 +332,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -331,6 +340,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -398,7 +410,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -406,6 +418,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -469,7 +484,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -477,6 +492,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -544,7 +562,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -552,6 +570,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -615,7 +636,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -623,6 +644,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -690,7 +714,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -698,6 +722,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -761,7 +788,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -769,6 +796,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -836,7 +866,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -844,6 +874,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -907,7 +940,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -915,6 +948,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-deploy_aks.yml
+++ b/jobs/ci-run/integration/gen/test-deploy_aks.yml
@@ -92,7 +92,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -100,6 +100,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-deploy_caas.yml
+++ b/jobs/ci-run/integration/gen/test-deploy_caas.yml
@@ -88,7 +88,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -96,6 +96,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test-microk8s:

--- a/jobs/ci-run/integration/gen/test-firewall.yml
+++ b/jobs/ci-run/integration/gen/test-firewall.yml
@@ -96,7 +96,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -104,6 +104,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -171,7 +174,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -179,6 +182,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -246,7 +252,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -254,6 +260,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - conditional-step:

--- a/jobs/ci-run/integration/gen/test-hooks.yml
+++ b/jobs/ci-run/integration/gen/test-hooks.yml
@@ -98,7 +98,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -106,6 +106,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -169,7 +172,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -177,6 +180,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -244,7 +250,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -252,6 +258,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -315,7 +324,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -323,6 +332,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-hooktools.yml
+++ b/jobs/ci-run/integration/gen/test-hooktools.yml
@@ -94,7 +94,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -102,6 +102,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -165,7 +168,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -173,6 +176,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-machine.yml
+++ b/jobs/ci-run/integration/gen/test-machine.yml
@@ -94,7 +94,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -102,6 +102,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -165,7 +168,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -173,6 +176,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-magma.yml
+++ b/jobs/ci-run/integration/gen/test-magma.yml
@@ -88,7 +88,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -96,6 +96,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test-microk8s:

--- a/jobs/ci-run/integration/gen/test-manual.yml
+++ b/jobs/ci-run/integration/gen/test-manual.yml
@@ -98,7 +98,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -106,6 +106,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -169,7 +172,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -177,6 +180,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -244,7 +250,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -252,6 +258,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -315,7 +324,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -323,6 +332,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-model.yml
+++ b/jobs/ci-run/integration/gen/test-model.yml
@@ -114,7 +114,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -122,6 +122,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -189,7 +192,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -197,6 +200,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -260,7 +266,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -268,6 +274,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -335,7 +344,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -343,6 +352,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -410,7 +422,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -418,6 +430,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -481,7 +496,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -489,6 +504,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -556,7 +574,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -564,6 +582,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -631,7 +652,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -639,6 +660,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -702,7 +726,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -710,6 +734,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -777,7 +804,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -785,6 +812,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -852,7 +882,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -860,6 +890,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -923,7 +956,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -931,6 +964,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -998,7 +1034,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -1006,6 +1042,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -1073,7 +1112,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -1081,6 +1120,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -1144,7 +1186,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -1152,6 +1194,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -1219,7 +1264,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -1227,6 +1272,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -1294,7 +1342,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -1302,6 +1350,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -1365,7 +1416,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -1373,6 +1424,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -1440,7 +1494,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -1448,6 +1502,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -1515,7 +1572,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -1523,6 +1580,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -1586,7 +1646,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -1594,6 +1654,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -1661,7 +1724,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -1669,6 +1732,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -1736,7 +1802,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -1744,6 +1810,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -1807,7 +1876,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -1815,6 +1884,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -1882,7 +1954,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -1890,6 +1962,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -1957,7 +2032,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -1965,6 +2040,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -2028,7 +2106,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -2036,6 +2114,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-network.yml
+++ b/jobs/ci-run/integration/gen/test-network.yml
@@ -98,7 +98,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -106,6 +106,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -173,7 +176,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -181,6 +184,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -248,7 +254,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -256,6 +262,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -319,7 +328,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -327,6 +336,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-refresh.yml
+++ b/jobs/ci-run/integration/gen/test-refresh.yml
@@ -98,7 +98,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -106,6 +106,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -169,7 +172,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -177,6 +180,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -244,7 +250,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -252,6 +258,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -315,7 +324,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -323,6 +332,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-relations.yml
+++ b/jobs/ci-run/integration/gen/test-relations.yml
@@ -102,7 +102,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -110,6 +110,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -173,7 +176,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -181,6 +184,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -248,7 +254,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -256,6 +262,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -319,7 +328,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -327,6 +336,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -394,7 +406,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -402,6 +414,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -465,7 +480,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -473,6 +488,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-resources.yml
+++ b/jobs/ci-run/integration/gen/test-resources.yml
@@ -98,7 +98,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -106,6 +106,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -169,7 +172,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -177,6 +180,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -244,7 +250,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -252,6 +258,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -315,7 +324,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -323,6 +332,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-secrets_iaas.yml
+++ b/jobs/ci-run/integration/gen/test-secrets_iaas.yml
@@ -94,7 +94,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -102,6 +102,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -165,7 +168,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -173,6 +176,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -236,7 +242,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -244,6 +250,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -307,7 +316,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -315,6 +324,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-secrets_k8s.yml
+++ b/jobs/ci-run/integration/gen/test-secrets_k8s.yml
@@ -90,7 +90,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -98,6 +98,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test-microk8s:
@@ -161,7 +164,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -169,6 +172,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test-microk8s:

--- a/jobs/ci-run/integration/gen/test-sidecar.yml
+++ b/jobs/ci-run/integration/gen/test-sidecar.yml
@@ -90,7 +90,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -98,6 +98,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test-microk8s:
@@ -161,7 +164,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -169,6 +172,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test-microk8s:

--- a/jobs/ci-run/integration/gen/test-smoke.yml
+++ b/jobs/ci-run/integration/gen/test-smoke.yml
@@ -98,7 +98,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -106,6 +106,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -169,7 +172,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -177,6 +180,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -244,7 +250,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -252,6 +258,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -315,7 +324,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -323,6 +332,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-spaces_ec2.yml
+++ b/jobs/ci-run/integration/gen/test-spaces_ec2.yml
@@ -96,7 +96,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -104,6 +104,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -171,7 +174,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -179,6 +182,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -246,7 +252,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -254,6 +260,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-storage.yml
+++ b/jobs/ci-run/integration/gen/test-storage.yml
@@ -94,7 +94,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -102,6 +102,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -169,7 +172,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -177,6 +180,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-unit.yml
+++ b/jobs/ci-run/integration/gen/test-unit.yml
@@ -94,7 +94,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -102,6 +102,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -165,7 +168,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -173,6 +176,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-upgrade.yml
+++ b/jobs/ci-run/integration/gen/test-upgrade.yml
@@ -88,7 +88,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -96,6 +96,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-upgrade_series.yml
+++ b/jobs/ci-run/integration/gen/test-upgrade_series.yml
@@ -88,7 +88,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -96,6 +96,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/gen/test-user.yml
+++ b/jobs/ci-run/integration/gen/test-user.yml
@@ -98,7 +98,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -106,6 +106,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -169,7 +172,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -177,6 +180,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -244,7 +250,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -252,6 +258,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -315,7 +324,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -323,6 +332,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -390,7 +402,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -398,6 +410,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:
@@ -461,7 +476,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -469,6 +484,9 @@
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
       - run-integration-test:

--- a/jobs/ci-run/integration/man/test-ck.yml
+++ b/jobs/ci-run/integration/man/test-ck.yml
@@ -39,7 +39,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
     builders:

--- a/jobs/ci-run/integration/man/test-kubeflow.yml
+++ b/jobs/ci-run/integration/man/test-kubeflow.yml
@@ -53,7 +53,7 @@
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:

--- a/tools/gen-wire-tests/main.go
+++ b/tools/gen-wire-tests/main.go
@@ -538,7 +538,7 @@ const Template = `
     - string:
         default: docker.io/jujuqabot
         description: "Operator docker image account name."
-        name: OPERATOR_IMAGE_ACCOUNT
+        name: PARAM_OPERATOR_IMAGE_ACCOUNT
     wrappers:
       - default-integration-test-wrapper
       - timeout:
@@ -546,6 +546,9 @@ const Template = `
           fail: true
           type: absolute
     builders:
+      - inject:
+          properties-content: |-
+            OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
 {{- if index $.MinVersions $task_name }}


### PR DESCRIPTION
By prefixing parameters with `PARAM_`, it forces a separation between parameters and environment variables in jenkins.
Parameters cannot be changed, whereas environment variables can. We should work to use the `PARAM_` prefix on all parameters.

This specifically fixes the OPERATOR_IMAGE_ACCOUNT env var, as it needs to be able to be set by the microk8s jobs.