### PR TITLE
Enable fuzz checking on amd64 post unit-tests for 30s

### DIFF
--- a/jobs/ci-run/scripts/snippet_run-unit-tests.sh
+++ b/jobs/ci-run/scripts/snippet_run-unit-tests.sh
@@ -36,7 +36,7 @@ if [[ "{GOTEST_TYPE}" == "race" ]]; then
         exit_code=$?
     fi
 elif [[ "{GOTEST_TYPE}" == "xunit-report" ]]; then
-    JUJU_GOMOD_MODE=vendor make test VERBOSE_CHECK=1 TEST_TIMEOUT=${{TEST_TIMEOUT}} | tee ${{WORKSPACE}}/go-unittest.out
+    JUJU_GOMOD_MODE=vendor make test VERBOSE_CHECK=1 FUZZ_CHECK=${{FUZZ_CHECK}} TEST_TIMEOUT=${{TEST_TIMEOUT}} | tee ${{WORKSPACE}}/go-unittest.out
     exit_code=$?
 fi
 set +o pipefail

--- a/jobs/ci-run/unittest/unittests.yml
+++ b/jobs/ci-run/unittest/unittests.yml
@@ -116,6 +116,7 @@
           GOTEST_TYPE: "xunit-report"
           TEST_TIMEOUT: "${TEST_TIMEOUT}"
           USE_TMPFS_FOR_MGO: "${USE_TMPFS_FOR_MGO}"
+          FUZZ_CHECKING: 1
     publishers:
       - junit:
           results: tests.xml
@@ -167,6 +168,7 @@
           GOTEST_TYPE: "xunit-report"
           TEST_TIMEOUT: "${TEST_TIMEOUT}"
           USE_TMPFS_FOR_MGO: "${USE_TMPFS_FOR_MGO}"
+          FUZZ_CHECKING: 0
     publishers:
       - junit:
           results: tests.xml
@@ -214,6 +216,7 @@
           GOTEST_TYPE: "xunit-report"
           TEST_TIMEOUT: "${TEST_TIMEOUT}"
           USE_TMPFS_FOR_MGO: "${USE_TMPFS_FOR_MGO}"
+          FUZZ_CHECKING: 0
     publishers:
       - junit:
           results: tests.xml
@@ -265,6 +268,7 @@
           GOTEST_TYPE: "xunit-report"
           TEST_TIMEOUT: "${TEST_TIMEOUT}"
           USE_TMPFS_FOR_MGO: "${USE_TMPFS_FOR_MGO}"
+          FUZZ_CHECKING: 0
     publishers:
       - junit:
           results: tests.xml
@@ -317,6 +321,7 @@
           GOTEST_TYPE: "race"
           TEST_TIMEOUT: "${TEST_TIMEOUT}"
           USE_TMPFS_FOR_MGO: "${USE_TMPFS_FOR_MGO}"
+          FUZZ_CHECKING: 0
     publishers:
         - junit:
             results: tests.xml
@@ -368,6 +373,7 @@
           GOTEST_TYPE: "race"
           TEST_TIMEOUT: "${TEST_TIMEOUT}"
           USE_TMPFS_FOR_MGO: "${USE_TMPFS_FOR_MGO}"
+          FUZZ_CHECKING: 0
     publishers:
         - junit:
             results: tests.xml


### PR DESCRIPTION
The following enables fuzz checking on amd64 for 30s to test the various scenarios. The more fuzzing we add the slower it will become. This will just test if it's actually useful. We could move this to it's own job for fuzzing only, that way we're not blowing out other jobs.