### PR TITLE
Add merge job for juju 3.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ python_base_path = $(shell which python3)
 
 .PHONY: ensure-venv
 ensure-venv:
-	pip3 install virtualenv
+	pip3 show virtualenv > /dev/null || pip3 install virtualenv
 	test -d venv || virtualenv -p $(python_base_path) $(virtualenv_dir)
 
 .PHONY: install-deps

--- a/jobs/github/mergejobs.yaml
+++ b/jobs/github/mergejobs.yaml
@@ -61,6 +61,7 @@
       - "3.1": {}
       - "3.2": {}
       - "3.3": {}
+      - "3.4": {}
     jobs:
       - 'github-juju-merge-jobs-{branch_name}'
 

--- a/jobs/github/scripts/snippet_build_basic-make-check.sh
+++ b/jobs/github/scripts/snippet_build_basic-make-check.sh
@@ -1,7 +1,7 @@
-    cd ${GOPATH}/src/${PROJECT_DIR}
+    cd ${{GOPATH}}/src/${{PROJECT_DIR}}
 
-    NEEDS_MGO=$(echo "${NEEDS_MGO}" | tr '[:upper:]' '[:lower:]')
-    if [ "${NEEDS_MGO}" = "true" ]; then
+    NEEDS_MGO=$(echo "${{NEEDS_MGO}}" | tr '[:upper:]' '[:lower:]')
+    if [ "${{NEEDS_MGO}}" = "true" ]; then
       action=$(snap info juju-db | grep -q "installed" || echo "install")
       if [ "$action" == "" ]; then
               action="refresh"
@@ -20,12 +20,12 @@
         sleep 10
       done
     fi
-    if [ ! -z "${EXTRA_PACKAGES}" ]; then
-      echo "Installing packages ${EXTRA_PACKAGES}"
-      sudo DEBIAN_FRONTEND=noninteractive apt-get install -y $(echo ${EXTRA_PACKAGES} | sed "s/,/ /g")
+    if [ ! -z "${{EXTRA_PACKAGES}}" ]; then
+      echo "Installing packages ${{EXTRA_PACKAGES}}"
+      sudo DEBIAN_FRONTEND=noninteractive apt-get install -y $(echo ${{EXTRA_PACKAGES}} | sed "s/,/ /g")
     fi
-    if [ ! -z "${EXTRA_SCRIPT}" ]; then
-      eval ${EXTRA_SCRIPT}
+    if [ ! -z "${{EXTRA_SCRIPT}}" ]; then
+      eval ${{EXTRA_SCRIPT}}
     fi
 
     goversion=1.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-jenkins-job-builder==3.12.0
+jenkins-job-builder==4.3.0
 setuptools==56.2.0


### PR DESCRIPTION
Add merge job for juju 3.4 branch.

The jenkins job builder version needed updating to work with newer Pythons.

Also fix Makefile to check if virtualenv is installed before trying to install it.
And fix some quoting issues in a bash script.