### PR TITLE
Fix typo in ci unit test node; remove centos unit tests

### DIFF
--- a/jobs/ci-run/unittest/unittests.yml
+++ b/jobs/ci-run/unittest/unittests.yml
@@ -46,7 +46,6 @@
 #               current-parameters: true
 #             - name: unit-tests-ppc64el
 #               current-parameters: true
-#             - name: unit-tests-centos9
 #               current-parameters: true
 
 
@@ -73,7 +72,7 @@
 
 - job:
     name: unit-tests-amd64
-    node: ephemeral-github-16c-64g-amd64
+    node: ephemeral-focal-16c-64g-amd64
     description: |-
       Build and run unit tests for amd64.
     wrappers:
@@ -274,7 +273,7 @@
 
 - job:
     name: 'unit-tests-race-amd64'
-    node: ephemeral-github-16c-64g-amd64
+    node: ephemeral-focal-16c-64g-amd64
     description: |-
       Build and run unit race tests for amd64.
     wrappers:
@@ -373,46 +372,6 @@
         - junit:
             results: tests.xml
             allow-empty-results: true
-
-- job:
-    name: 'unit-tests-centos9'
-    description: |-
-      Build and run unit race tests on centos9 for amd64.
-    node: ephemeral-centos9-8c-32g-amd64
-    wrappers:
-      - default-unit-test-wrapper
-    parameters:
-      - validating-string:
-          description: The git short hash for the commit you wish to test
-          name: SHORT_GIT_COMMIT
-          regex: ^\S{7}$
-          msg: Enter a valid 7 char git sha
-      - string:
-          name: USE_TMPFS_FOR_MGO
-          description: "Set to 1 to use a tmpfs volume for hosting mongo data"
-      - string:
-          name: series
-          default: ""
-          description: "Series used for deploying"
-      - string:
-          name: BOOTSTRAP_SERIES
-          default: ""
-          description: "Series to used for bootstrapping"
-      - string:
-          name: GOVERSION
-          default: "1.17"
-          description: "Go version to use for unit tests"
-    builders:
-      - install-go
-      - get-s3-source-payload
-      - set-test-description
-      - shell:
-          !include-raw: ../scripts/centos-unit-test.sh
-    publishers:
-      # centos-unit-test.sh puts the tests.xml file in the right place, no need to grab it.
-      - junit:
-          results: tests.xml
-          allow-empty-results: true
 
 - wrapper:
     name: default-unit-test-wrapper

--- a/tests/suites/static_analysis/lint_yaml.sh
+++ b/tests/suites/static_analysis/lint_yaml.sh
@@ -72,7 +72,6 @@ jobs:
     - unit-tests-s390x
     - unit-tests-race-arm64
     - unit-tests-ppc64el
-    - unit-tests-centos9
     - unit-tests-arm64
     - nw-deploy-jammy-s390x-lxd
     - nw-deploy-jammy-ppc64el-lxd


### PR DESCRIPTION
There was a typo in the amd64 unit test nodes.
Also remove unused centos9 unit test job.