### PR TITLE
Disable coslite test on 2.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ gen-wire-tests:
 	@go run ./tools/gen-wire-tests/main.go \
 		"${JUJU_REPO_PATH}/tests/suites" \
 		"./jobs/ci-run/integration/gen" \
-		"3.3" \
+		"3.4" \
 		<"${config}"
 
 .PHONY: clean

--- a/jobs/ci-run/integration/gen/test-coslite.yml
+++ b/jobs/ci-run/integration/gen/test-coslite.yml
@@ -101,10 +101,16 @@
             OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
-      - run-integration-test-microk8s:
-            test_name: 'coslite'
-            setup_steps: ''
-            task_name: ''
-            skip_tasks: ''
+      - conditional-step:
+          condition-kind: regex-match
+          regex: "^[4-9].*|^3\\.([1-9]|\\d{2,})(\\.|-).*"
+          label: "${JUJU_VERSION}"
+          on-evaluation-failure: "dont-run"
+          steps:
+            - run-integration-test-microk8s:
+                  test_name: 'coslite'
+                  setup_steps: ''
+                  task_name: ''
+                  skip_tasks: ''
     publishers:
       - integration-artifacts

--- a/tools/gen-wire-tests/juju.config
+++ b/tools/gen-wire-tests/juju.config
@@ -22,6 +22,8 @@ folders:
       3.3
     test_dashboard_deploy:
       3.1
+    test_deploy_coslite:
+      3.1
   timeout:
     secrets_iaas:
       test_secrets_vault: 60


### PR DESCRIPTION
Disables the coslite test on 2.9 because it appears coslite no-longer supports 2.9.