### PR TITLE
Apt update before apt install

### DIFF
--- a/jobs/common/pre-reqs.yaml
+++ b/jobs/common/pre-reqs.yaml
@@ -194,6 +194,7 @@
         # Steps come from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt
         set -eux
 
+        sudo DEBIAN_FRONTEND=noninteractive apt-get update
         sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl apt-transport-https lsb-release gnupg
 
         curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null


### PR DESCRIPTION
We were attempting to install some azure-cli pre-requisites before we had run apt update, which was leading to failures in the cleanup job

## QA steps

See success here:
https://jenkins.juju.canonical.com/view/cleanup-jobs/job/z-clean-resources-azure/14459/