### PR TITLE
Snap install microceph

### DIFF
--- a/jobs/ci-run/integration/common/test-runner.sh
+++ b/jobs/ci-run/integration/common/test-runner.sh
@@ -52,6 +52,9 @@ while [ $attempts -lt 3 ]; do
     if [ ! "$(which petname >/dev/null 2>&1)" ]; then
         sudo snap install petname || true
     fi
+    if [ ! "$(which microceph >/dev/null 2>&1)" ]; then
+        sudo snap install microceph || true
+    fi
     # shellcheck disable=SC2193
     if [ "${{BOOTSTRAP_PROVIDER:-}}" = "ec2" ]; then
         if [ ! "$(which aws >/dev/null 2>&1)" ]; then


### PR DESCRIPTION
We require microceph to be installed so we can bootstrap a HA envrionment. The integration tests will follow in a juju/juju PR.