### PR TITLE
Bump go-version for packaging source

### DIFF
--- a/jobs/ci-run/utils.yml
+++ b/jobs/ci-run/utils.yml
@@ -124,7 +124,7 @@
         fi
 
         export PATH="/snap/bin:$PATH"
-        sudo snap refresh go --channel=1.17/stable || sudo snap install go --channel=1.17/stable --classic
+        sudo snap refresh go --channel=1.21/stable || sudo snap install go --channel=1.21/stable --classic
 
         # TODO - fix this workaround
         # As we clone the full history (can't shallow clone otherwise queued jobs miss


### PR DESCRIPTION
We're getting failures because the older version of the go compiler didn't understand patch versions in the go.mod directive.

See:

```
06:14:36 /home/jenkins/workspace/package-juju-source/build/src/github.com/juju/juju/go.mod:3: invalid go version '1.21.6': must match format 1.23
06:14:36 make: *** [Makefile:521: vendor-dependencies] Error 1
```