### PR TITLE
Only run k8s smoke tests on 4.0 or later

### DIFF
--- a/jobs/ci-run/integration/gen/test-smoke_k8s.yml
+++ b/jobs/ci-run/integration/gen/test-smoke_k8s.yml
@@ -101,10 +101,16 @@
             OPERATOR_IMAGE_ACCOUNT=${PARAM_OPERATOR_IMAGE_ACCOUNT}
       - wait-for-cloud-init
       - prepare-integration-test
-      - run-integration-test-microk8s:
-            test_name: 'smoke_k8s'
-            setup_steps: ''
-            task_name: ''
-            skip_tasks: ''
+      - conditional-step:
+          condition-kind: regex-match
+          regex: "^[5-9].*|^4\\.([0-9]|\\d{2,})(\\.|-).*"
+          label: "${JUJU_VERSION}"
+          on-evaluation-failure: "dont-run"
+          steps:
+            - run-integration-test-microk8s:
+                  test_name: 'smoke_k8s'
+                  setup_steps: ''
+                  task_name: ''
+                  skip_tasks: ''
     publishers:
       - integration-artifacts

--- a/tools/gen-wire-tests/juju.config
+++ b/tools/gen-wire-tests/juju.config
@@ -28,6 +28,8 @@ folders:
       3.4
     test_actions_params:
       4.0
+    smoke_k8s-test_deploy:
+      4.0
   timeout:
     secrets_iaas:
       test_secrets_vault: 60


### PR DESCRIPTION
The k8s smoke tests were added in juju 4.0.
But to filter them, we need to optionally include the test suite name in the filter expression, because some other tests have the same name.
The result - only the change we want - is seen in the test-smoke_k8s.yaml file