### PR TITLE
Increase test_deploy_charms timeout

### DIFF
--- a/jobs/ci-run/integration/gen/test-deploy.yml
+++ b/jobs/ci-run/integration/gen/test-deploy.yml
@@ -418,7 +418,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:
@@ -492,7 +492,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 50
           fail: true
           type: absolute
     builders:

--- a/tools/gen-wire-tests/juju.config
+++ b/tools/gen-wire-tests/juju.config
@@ -40,6 +40,7 @@ folders:
       test_deploy_magma: 90
     deploy:
       test_deploy_bundles: 50
+      test_deploy_charms: 50
   unstable:
     deploy:
       lxd:


### PR DESCRIPTION
Job was timing out at 30 minutes despite being close to finishing.