### PR TITLE
Fix conditional installs

### DIFF
--- a/jobs/ci-run/integration/common/test-runner.sh
+++ b/jobs/ci-run/integration/common/test-runner.sh
@@ -37,24 +37,24 @@ sudo apt-get -y update
 # set, so retries succeed.
 attempts=0
 while [ $attempts -lt 3 ]; do
-    if [ ! "$(which jq >/dev/null 2>&1)" ]; then
+    if ! which jq >/dev/null 2>&1; then
         sudo snap install jq || true
     fi
-    if [ ! "$(which yq >/dev/null 2>&1)" ]; then
+    if ! which yq >/dev/null 2>&1; then
         sudo snap install yq || true
     fi
-    if [ ! "$(which shellcheck >/dev/null 2>&1)" ]; then
+    if ! which shellcheck >/dev/null 2>&1; then
         sudo snap install shellcheck || true
     fi
-    if [ ! "$(which expect >/dev/null 2>&1)" ]; then
+    if ! which expect >/dev/null 2>&1; then
         sudo apt-get -y install expect || true
     fi
-    if [ ! "$(which petname >/dev/null 2>&1)" ]; then
+    if ! which petname >/dev/null 2>&1; then
         sudo snap install petname || true
     fi
     # shellcheck disable=SC2193
     if [ "${{BOOTSTRAP_PROVIDER:-}}" = "ec2" ]; then
-        if [ ! "$(which aws >/dev/null 2>&1)" ]; then
+        if ! which aws >/dev/null 2>&1; then
             sudo snap install aws-cli --classic || true
         fi
 
@@ -71,7 +71,7 @@ while [ $attempts -lt 3 ]; do
     fi
     # shellcheck disable=SC2193
     if [ "${{BOOTSTRAP_PROVIDER:-}}" = "azure" ]; then
-        if [ ! "$(which az >/dev/null 2>&1)" ]; then
+        if ! which az >/dev/null 2>&1; then
             curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
         fi
 


### PR DESCRIPTION
It turns out our conditional installs were broken, leading us to attempt to install every time

This is mostly ok, because the installs are mostly idempotent. However, installing azure `az` cli was more complex, and has started breaking

Fix these conditional steps to properly detect if a binary is present

For conditional install implementation, see here:
https://stackoverflow.com/questions/49849957/bash-conditional-based-on-exit-code-of-command

## QA Steps

observe that the following integration test succeeds:
https://jenkins.juju.canonical.com/job/test-network-test-network-health-azure/1911/console