### PR TITLE
fix: bionic was incorrectly used on integration job

### DIFF
--- a/jobs/ci-run/integration/integrationtests.yml
+++ b/jobs/ci-run/integration/integrationtests.yml
@@ -284,7 +284,7 @@
     project-type: "multijob"
     description: |-
       intergration-arm64 runs the new shell integration tests with arm64 workloads.
-    node: ephemeral-bionic-8c-32g-arm64
+    node: noop-parent-jobs
     concurrent: true
     wrappers:
       - default-integration-test-wrapper


### PR DESCRIPTION
Bionic does not support openjdk 17 which jenkins needs. This was an incorrect use of a builder node rather than using a noop builder.