### PR TITLE
fix: GO111MODULE broken with go 1.22 update

### DIFF
--- a/jobs/ci-run/scripts/centos-unit-test.sh
+++ b/jobs/ci-run/scripts/centos-unit-test.sh
@@ -37,7 +37,7 @@ else
 fi
 
 # This will be used to generate reports for jenkins.
-GO111MODULE=off go get github.com/tebeka/go2xunit
+go install github.com/tebeka/go2xunit@latest
 
 cd ${full_path}
 

--- a/jobs/ci-run/unittest/unittests.yml
+++ b/jobs/ci-run/unittest/unittests.yml
@@ -106,8 +106,8 @@
       - apt-install:
           packages: gcc squashfuse
       - setup-go-environment
-      - go-get:
-          modules: github.com/tebeka/go2xunit
+      - go-install:
+          modules: github.com/tebeka/go2xunit@latest
       - get-s3-source-payload
       - description-setter:
           description: "${JUJU_VERSION} ${SHORT_GIT_COMMIT}"
@@ -158,8 +158,8 @@
       - apt-install:
           packages: gcc squashfuse
       - setup-go-environment
-      - go-get:
-          modules: github.com/tebeka/go2xunit
+      - go-install:
+          modules: github.com/tebeka/go2xunit@latest
       - get-s3-source-payload
       - description-setter:
           description: "${JUJU_VERSION} ${SHORT_GIT_COMMIT}"
@@ -206,8 +206,8 @@
       - apt-install:
           packages: gcc squashfuse
       - setup-go-environment
-      - go-get:
-          modules: github.com/tebeka/go2xunit
+      - go-install:
+          modules: github.com/tebeka/go2xunit@latest
       - get-s3-source-payload
       - description-setter:
           description: "${JUJU_VERSION} ${SHORT_GIT_COMMIT}"
@@ -258,8 +258,8 @@
       - apt-install:
           packages: gcc squashfuse
       - setup-go-environment
-      - go-get:
-          modules: github.com/tebeka/go2xunit
+      - go-install:
+          modules: github.com/tebeka/go2xunit@latest
       - get-s3-source-payload
       - description-setter:
           description: "${JUJU_VERSION} ${SHORT_GIT_COMMIT}"
@@ -311,8 +311,8 @@
       - apt-install:
           packages: gcc squashfuse
       - setup-go-environment
-      - go-get:
-          modules: github.com/tebeka/go2xunit
+      - go-install:
+          modules: github.com/tebeka/go2xunit@latest
       - get-s3-source-payload
       - description-setter:
           description: "${JUJU_VERSION} ${SHORT_GIT_COMMIT}"
@@ -363,8 +363,8 @@
       - apt-install:
           packages: gcc squashfuse
       - setup-go-environment
-      - go-get:
-          modules: github.com/tebeka/go2xunit
+      - go-install:
+          modules: github.com/tebeka/go2xunit@latest
       - get-s3-source-payload
       - description-setter:
           description: "${JUJU_VERSION} ${SHORT_GIT_COMMIT}"

--- a/jobs/common/pre-reqs.yaml
+++ b/jobs/common/pre-reqs.yaml
@@ -33,12 +33,12 @@
             {packages}
 
 - builder:
-    name: go-get
+    name: go-install
     builders:
       - shell: |-
           #!/bin/bash
           set -eux
-          GO111MODULE=off go get {modules}
+          go install {modules}
 
 # install-common-tools installs the common set of tools needed between 99% of
 # jobs in this repo. This builder assumes the install target is Ubuntu.

--- a/jobs/github/scripts/run-snippet-compat.sh
+++ b/jobs/github/scripts/run-snippet-compat.sh
@@ -140,7 +140,7 @@ sudo su - "$USER" -c "$(echo "$SAVE_ENV" && cat <<'EOS'
     if [ -f "${{WORKSPACE}}/go-unittest.out" ]; then
         # This will be used to generate reports for jenkins assuming there is
         # a file "go-unittest.out" in the WORKSPACE.
-        GO111MODULE=off go get -v github.com/tebeka/go2xunit
+        go install -v github.com/tebeka/go2xunit@latest
         "${{GOPATH}}/bin/go2xunit" -fail -input "${{WORKSPACE}}/go-unittest.out" -output "${{WORKSPACE}}/tests.xml"
     fi
 

--- a/jobs/github/scripts/run-snippet-lxd.sh
+++ b/jobs/github/scripts/run-snippet-lxd.sh
@@ -282,7 +282,7 @@ lxc exec "${{CONTAINER_NAME}}" -- sudo -u ubuntu bash <<"EOT"
     if [ -f "${{WORKSPACE}}/go-unittest.out" ]; then
         # This will be used to generate reports for jenkins assuming there is
         # a file "go-unittest.out" in the WORKSPACE.
-        GO111MODULE=off go get -v github.com/tebeka/go2xunit
+        go install -v github.com/tebeka/go2xunit@latest
         "${{GOPATH}}/bin/go2xunit" -fail -input "${{WORKSPACE}}/go-unittest.out" -output "${{WORKSPACE}}/tests.xml"
     fi
 


### PR DESCRIPTION
Go no longer support go get outside of a module with the GO111MODULE environmental var: https://tip.golang.org/doc/go1.22. Change the uses of this to go install instead. A version for the modules is required since it would normally use the go.mod one.