### PR TITLE
fix(pylibjuju): restore + fix pylibjuju check merge jobs

### DIFF
--- a/jobs/github/github-check-merge.yml
+++ b/jobs/github/github-check-merge.yml
@@ -59,12 +59,9 @@
           needs_mgo: true
       - worker:
           project_dir: "github.com/juju/worker"
-      # tiradojm
-      # 2022-11-24 Python-libjuju logistics have been moved to
-      # GitHub
-      #   - python-libjuju:
-      #     project_dir: "github.com/juju/python-libjuju"
-      #     build_script: "scripts/snippet_build_check-juju-python-libjuju.sh"
+      - python-libjuju:
+          project_dir: "github.com/juju/python-libjuju"
+          build_script: "scripts/snippet_build_check-juju-python-libjuju.sh"
       - schemagen:
           project_dir: "github.com/juju/schemagen"
       - ratelimit:

--- a/jobs/github/scripts/goversion.sh
+++ b/jobs/github/scripts/goversion.sh
@@ -5,7 +5,7 @@ set +e
 gomod=$(curl -fs "https://raw.githubusercontent.com/$ghprbGhRepository/$MERGE_COMMIT/go.mod")
 rval=$?
 if [ $rval -ne 0 ]; then
-  echo "GOVERSION=''" > "${WORKSPACE}/goversion"
+  echo "GOVERSION=" > "${WORKSPACE}/goversion"
   exit 0
 fi
 set -e

--- a/jobs/github/scripts/snippet_build_check-juju-python-libjuju.sh
+++ b/jobs/github/scripts/snippet_build_check-juju-python-libjuju.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# even though we're a python lib, we're in a go path because of the way
+# the checkout setup runs and changing that will cause other projects to
+# break.
+cd ${GOPATH}/src/github.com/juju/python-libjuju
+# Fail if anything unexpected happens
+set -e
+
+sudo add-apt-repository ppa:deadsnakes/ppa
+sudo apt-get update -q
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git gcc make tox \
+	python3.8 python3.9 python3.10 python3-pip \
+	python3.8-dev python3.8-distutils python3.9-dev python3.9-distutils python3.10-dev python3.10-distutils
+
+set +e  # Will fail in reports gen if any errors occur
+set -o pipefail  # Need to error for make, not tees' success.
+
+export PATH="$HOME/.local/bin:$PATH"
+
+make test
+check_exit=$?
+
+set +o pipefail
+echo `date --rfc-3339=seconds` "ran make test"


### PR DESCRIPTION
It turns out in 2022[!] we accidentally removed the pylibjuju check merge jobs from juju-qa-jenkins.

This went unnoticed since then, since `make push` does not remove job not in jjb IaC

However, the job recently broke. To fix this:
1) The job had to be restored
2) A fix had to be implemented

It turns out the job was broken in two ways:
1) We tried to install python 3.6 (ancient) on Noble, which failed 2) In the case a repo does not have a go.mod file, we incorrectly set
   GOVERSION to '' (i.e. a string containing two quote marks) instead of
   an empty string. This lead to failures later down the line

## QA Steps

See successful merges in pylibjuju e.g.
https://github.com/juju/python-libjuju/pull/1067