### PR TITLE
chore(python): install py3.11 for pylibjuju check

### DIFF
--- a/jobs/github/scripts/snippet_build_check-juju-python-libjuju.sh
+++ b/jobs/github/scripts/snippet_build_check-juju-python-libjuju.sh
@@ -8,9 +8,11 @@ set -e
 
 sudo add-apt-repository ppa:deadsnakes/ppa
 sudo apt-get update -q
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git gcc make tox \
-	python3.8 python3.9 python3.10 python3-pip \
-	python3.8-dev python3.8-distutils python3.9-dev python3.9-distutils python3.10-dev python3.10-distutils
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git gcc make tox python3-pip  \
+	python3.8 python3.8-dev python3.8-distutils \
+	python3.9 python3.9-dev python3.9-distutils \
+	python3.10 python3.10-dev python3.10-distutils \
+	python3.11 python3.11-dev python3.11-distutils
 
 set +e  # Will fail in reports gen if any errors occur
 set -o pipefail  # Need to error for make, not tees' success.


### PR DESCRIPTION
Pylibjuju now runs it's unit tests against a new python version, python 3.11.

Add 3.11 to the versions of python we install in the pylibjuju build check snippet

The fact we do not install python 3.11 resulted in the following failure:
https://jenkins.juju.canonical.com/view/github-jobs/job/github-check-merge-juju-python-libjuju/797/

# QA Steps

See the follow job, which succeeds thanks to this patch

https://jenkins.juju.canonical.com/view/github-jobs/job/github-check-merge-juju-python-libjuju/798/console