### PR TITLE
fix(dependencies): install charmcraft if missing in test-runner script

### DIFF
--- a/jobs/ci-run/integration/common/test-runner.sh
+++ b/jobs/ci-run/integration/common/test-runner.sh
@@ -37,6 +37,9 @@ sudo apt-get -y update
 # set, so retries succeed.
 attempts=0
 while [ $attempts -lt 3 ]; do
+    if ! which charmcraft >/dev/null 2>&1; then
+        sudo snap install charmcraft --classic || true
+    fi
     if ! which jq >/dev/null 2>&1; then
         sudo snap install jq || true
     fi


### PR DESCRIPTION
Ensure charmcraft is installed before running integration tests, similar to how jq is handled. This should fix several red test in JUJU gating ci :

* tests/suites/deploy
* tests/suites/hooks
* tests/suites/relations
* tests/suites/sidecar
* tests/suites/spaces_ec2
* tests/suites/storage