### PR TITLE
chore(jobs): increase timeout for GCE clean-up job

### DIFF
--- a/jobs/z-jobs/z-clean-resources-gce.yml
+++ b/jobs/z-jobs/z-clean-resources-gce.yml
@@ -50,5 +50,5 @@
     wrappers:
     - timeout:
         fail: true
-        timeout: 10
+        timeout: 30
         type: absolute


### PR DESCRIPTION
- Increased the timeout for the GCE clean-up job to 30 minutes.