### PR TITLE
test: add new ci tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,6 @@ dot-graph:
 gen-wire-tests:
 	$(eval config := "./tools/gen-wire-tests/juju.config")
 	@go run ./tools/gen-wire-tests/main.go \
-		"${JUJU_REPO_PATH}/tests/suites" \
 		"./jobs/ci-run/integration/gen" \
 		"main" \
 		<"${config}"

--- a/jobs/ci-run/integration/gen/test-constraints.yml
+++ b/jobs/ci-run/integration/gen/test-constraints.yml
@@ -36,13 +36,17 @@
           current-parameters: true
         - name: 'test-constraints-test-constraints-common-lxd'
           current-parameters: true
+        - name: 'test-constraints-test-constraints-model-google'
+          current-parameters: true
+        - name: 'test-constraints-test-constraints-model-lxd'
+          current-parameters: true
 
 - job:
     name: test-constraints-test-constraints-common-google
     node: ephemeral-noble-small-amd64
     concurrent: true
     description: |-
-      Test constraints suite on google
+      Test test_constraints_common in constraints suite on google
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -105,8 +109,8 @@
       - run-integration-test:
             test_name: 'constraints'
             setup_steps: ''
-            task_name: ''
-            skip_tasks: ''
+            task_name: 'test_constraints_common'
+            skip_tasks: 'test_constraints_model'
     publishers:
       - integration-artifacts
 
@@ -115,7 +119,7 @@
     node: ephemeral-noble-8c-32g-amd64
     concurrent: true
     description: |-
-      Test constraints suite on lxd
+      Test test_constraints_common in constraints suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -174,7 +178,167 @@
       - run-integration-test:
             test_name: 'constraints'
             setup_steps: ''
-            task_name: ''
-            skip_tasks: ''
+            task_name: 'test_constraints_common'
+            skip_tasks: 'test_constraints_model'
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-constraints-test-constraints-model-google
+    node: ephemeral-noble-small-amd64
+    concurrent: true
+    description: |-
+      Test test_constraints_model in constraints suite on google
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{{7}}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'google'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'gce'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - select-oci-registry
+      - wait-for-cloud-init
+      - prepare-integration-test
+      - conditional-step:
+          # Only run on regexp version match.
+          # Accounts for tests which do not exist
+          # until a given Juju version.
+          condition-kind: regex-match
+          regex: "^[4-9].*|^3\\.([6-9]|\\d{{2,}})(\\.|-).*"
+          label: "${{JUJU_VERSION}}"
+          on-evaluation-failure: "dont-run"
+          steps:
+            - run-integration-test:
+                  test_name: 'constraints'
+                  setup_steps: ''
+                  task_name: 'test_constraints_model'
+                  skip_tasks: 'test_constraints_common'
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-constraints-test-constraints-model-lxd
+    node: ephemeral-noble-8c-32g-amd64
+    concurrent: true
+    description: |-
+      Test test_constraints_model in constraints suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{{7}}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'localhost'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - select-oci-registry
+      - wait-for-cloud-init
+      - prepare-integration-test
+      - conditional-step:
+          # Only run on regexp version match.
+          # Accounts for tests which do not exist
+          # until a given Juju version.
+          condition-kind: regex-match
+          regex: "^[4-9].*|^3\\.([6-9]|\\d{{2,}})(\\.|-).*"
+          label: "${{JUJU_VERSION}}"
+          on-evaluation-failure: "dont-run"
+          steps:
+            - run-integration-test:
+                  test_name: 'constraints'
+                  setup_steps: ''
+                  task_name: 'test_constraints_model'
+                  skip_tasks: 'test_constraints_common'
     publishers:
       - integration-artifacts

--- a/jobs/ci-run/integration/gen/test-relations.yml
+++ b/jobs/ci-run/integration/gen/test-relations.yml
@@ -44,6 +44,10 @@
           current-parameters: true
         - name: 'test-relations-test-relation-list-app-lxd'
           current-parameters: true
+        - name: 'test-relations-test-relation-model-get-aws'
+          current-parameters: true
+        - name: 'test-relations-test-relation-model-get-lxd'
+          current-parameters: true
 
 - job:
     name: test-relations-test-relation-data-exchange-aws
@@ -114,7 +118,7 @@
             test_name: 'relations'
             setup_steps: ''
             task_name: 'test_relation_data_exchange'
-            skip_tasks: 'test_relation_departing_unit,test_relation_list_app'
+            skip_tasks: 'test_relation_departing_unit,test_relation_list_app,test_relation_model_get'
     publishers:
       - integration-artifacts
 
@@ -183,7 +187,7 @@
             test_name: 'relations'
             setup_steps: ''
             task_name: 'test_relation_data_exchange'
-            skip_tasks: 'test_relation_departing_unit,test_relation_list_app'
+            skip_tasks: 'test_relation_departing_unit,test_relation_list_app,test_relation_model_get'
     publishers:
       - integration-artifacts
 
@@ -256,7 +260,7 @@
             test_name: 'relations'
             setup_steps: ''
             task_name: 'test_relation_departing_unit'
-            skip_tasks: 'test_relation_data_exchange,test_relation_list_app'
+            skip_tasks: 'test_relation_data_exchange,test_relation_list_app,test_relation_model_get'
     publishers:
       - integration-artifacts
 
@@ -325,7 +329,7 @@
             test_name: 'relations'
             setup_steps: ''
             task_name: 'test_relation_departing_unit'
-            skip_tasks: 'test_relation_data_exchange,test_relation_list_app'
+            skip_tasks: 'test_relation_data_exchange,test_relation_list_app,test_relation_model_get'
     publishers:
       - integration-artifacts
 
@@ -398,7 +402,7 @@
             test_name: 'relations'
             setup_steps: ''
             task_name: 'test_relation_list_app'
-            skip_tasks: 'test_relation_data_exchange,test_relation_departing_unit'
+            skip_tasks: 'test_relation_data_exchange,test_relation_departing_unit,test_relation_model_get'
     publishers:
       - integration-artifacts
 
@@ -467,6 +471,166 @@
             test_name: 'relations'
             setup_steps: ''
             task_name: 'test_relation_list_app'
-            skip_tasks: 'test_relation_data_exchange,test_relation_departing_unit'
+            skip_tasks: 'test_relation_data_exchange,test_relation_departing_unit,test_relation_model_get'
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-relations-test-relation-model-get-aws
+    node: ephemeral-noble-small-amd64
+    concurrent: true
+    description: |-
+      Test test_relation_model_get in relations suite on aws
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{{7}}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'aws'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'ec2'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - select-oci-registry
+      - wait-for-cloud-init
+      - prepare-integration-test
+      - conditional-step:
+          # Only run on regexp version match.
+          # Accounts for tests which do not exist
+          # until a given Juju version.
+          condition-kind: regex-match
+          regex: "^[4-9].*|^3\\.([6-9]|\\d{{2,}})(\\.|-).*"
+          label: "${{JUJU_VERSION}}"
+          on-evaluation-failure: "dont-run"
+          steps:
+            - run-integration-test:
+                  test_name: 'relations'
+                  setup_steps: ''
+                  task_name: 'test_relation_model_get'
+                  skip_tasks: 'test_relation_data_exchange,test_relation_departing_unit,test_relation_list_app'
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-relations-test-relation-model-get-lxd
+    node: ephemeral-noble-8c-32g-amd64
+    concurrent: true
+    description: |-
+      Test test_relation_model_get in relations suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{{7}}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'localhost'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - select-oci-registry
+      - wait-for-cloud-init
+      - prepare-integration-test
+      - conditional-step:
+          # Only run on regexp version match.
+          # Accounts for tests which do not exist
+          # until a given Juju version.
+          condition-kind: regex-match
+          regex: "^[4-9].*|^3\\.([6-9]|\\d{{2,}})(\\.|-).*"
+          label: "${{JUJU_VERSION}}"
+          on-evaluation-failure: "dont-run"
+          steps:
+            - run-integration-test:
+                  test_name: 'relations'
+                  setup_steps: ''
+                  task_name: 'test_relation_model_get'
+                  skip_tasks: 'test_relation_data_exchange,test_relation_departing_unit,test_relation_list_app'
     publishers:
       - integration-artifacts

--- a/jobs/ci-run/integration/gen/test-secrets_iaas.yml
+++ b/jobs/ci-run/integration/gen/test-secrets_iaas.yml
@@ -38,6 +38,8 @@
           current-parameters: true
         - name: 'test-secrets_iaas-test-secrets-juju-lxd'
           current-parameters: true
+        - name: 'test-secrets_iaas-test-secrets-k8s-lxd'
+          current-parameters: true
         - name: 'test-secrets_iaas-test-secrets-vault-lxd'
           current-parameters: true
         - name: 'test-secrets_iaas-test-user-secret-drain-lxd'
@@ -117,7 +119,7 @@
                   test_name: 'secrets_iaas'
                   setup_steps: ''
                   task_name: 'test_secret_drain'
-                  skip_tasks: 'test_secrets_cmr,test_secrets_juju,test_secrets_vault,test_user_secret_drain'
+                  skip_tasks: 'test_secrets_cmr,test_secrets_juju,test_secrets_k8s,test_secrets_vault,test_user_secret_drain'
     publishers:
       - integration-artifacts
 
@@ -195,7 +197,7 @@
                   test_name: 'secrets_iaas'
                   setup_steps: ''
                   task_name: 'test_secrets_cmr'
-                  skip_tasks: 'test_secret_drain,test_secrets_juju,test_secrets_vault,test_user_secret_drain'
+                  skip_tasks: 'test_secret_drain,test_secrets_juju,test_secrets_k8s,test_secrets_vault,test_user_secret_drain'
     publishers:
       - integration-artifacts
 
@@ -273,7 +275,85 @@
                   test_name: 'secrets_iaas'
                   setup_steps: ''
                   task_name: 'test_secrets_juju'
-                  skip_tasks: 'test_secret_drain,test_secrets_cmr,test_secrets_vault,test_user_secret_drain'
+                  skip_tasks: 'test_secret_drain,test_secrets_cmr,test_secrets_k8s,test_secrets_vault,test_user_secret_drain'
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-secrets_iaas-test-secrets-k8s-lxd
+    node: ephemeral-noble-8c-32g-amd64
+    concurrent: true
+    description: |-
+      Test test_secrets_k8s in secrets_iaas suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{{7}}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'localhost'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: ''
+        description: 'Ubuntu series to use when bootstrapping Juju'
+        name: BOOTSTRAP_SERIES
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - select-oci-registry
+      - wait-for-cloud-init
+      - prepare-integration-test
+      - conditional-step:
+          # Only run on regexp version match.
+          # Accounts for tests which do not exist
+          # until a given Juju version.
+          condition-kind: regex-match
+          regex: "^[4-9].*|^3\\.([6-9]|\\d{{2,}})(\\.|-).*"
+          label: "${{JUJU_VERSION}}"
+          on-evaluation-failure: "dont-run"
+          steps:
+            - run-integration-test:
+                  test_name: 'secrets_iaas'
+                  setup_steps: ''
+                  task_name: 'test_secrets_k8s'
+                  skip_tasks: 'test_secret_drain,test_secrets_cmr,test_secrets_juju,test_secrets_vault,test_user_secret_drain'
     publishers:
       - integration-artifacts
 
@@ -351,7 +431,7 @@
                   test_name: 'secrets_iaas'
                   setup_steps: ''
                   task_name: 'test_secrets_vault'
-                  skip_tasks: 'test_secret_drain,test_secrets_cmr,test_secrets_juju,test_user_secret_drain'
+                  skip_tasks: 'test_secret_drain,test_secrets_cmr,test_secrets_juju,test_secrets_k8s,test_user_secret_drain'
     publishers:
       - integration-artifacts
 
@@ -429,6 +509,6 @@
                   test_name: 'secrets_iaas'
                   setup_steps: ''
                   task_name: 'test_user_secret_drain'
-                  skip_tasks: 'test_secret_drain,test_secrets_cmr,test_secrets_juju,test_secrets_vault'
+                  skip_tasks: 'test_secret_drain,test_secrets_cmr,test_secrets_juju,test_secrets_k8s,test_secrets_vault'
     publishers:
       - integration-artifacts

--- a/tools/gen-wire-tests/juju.config
+++ b/tools/gen-wire-tests/juju.config
@@ -3,6 +3,12 @@ folders:
     deploy-test_deploy_os:
       4.0
   introduced:
+    test_relation_model_get:
+      3.6
+    test_constraints_model:
+      3.6
+    secrets_iaas-test_secrets_k8s:
+      3.6
     cloud_azure-test_managed_identity:
       3.6
     test_firewall_ssh:


### PR DESCRIPTION
Includes new tests for :
- k8s secrets
-  relation model get
- model constraints

Also a drive by makefile fix for the gen wire tests tool since an arg was removed.