### PR TITLE
fix: remove obsolete provided specific test setup

### DIFF
--- a/jobs/ci-run/integration/builders.yaml
+++ b/jobs/ci-run/integration/builders.yaml
@@ -4,6 +4,8 @@
     name: 'prepare-integration-test'
     builders:
     - set-common-environment
+    # TODO - the test itself should install the az cli if needed.
+    - install-azure-cli
     - get-s3-source-payload
     - set-test-description
 

--- a/jobs/ci-run/integration/common/test-runner.sh
+++ b/jobs/ci-run/integration/common/test-runner.sh
@@ -63,34 +63,6 @@ while [ $attempts -lt 3 ]; do
     if [ ! "$(which microceph >/dev/null 2>&1)" ]; then
         sudo snap install microceph || true
     fi
-    # shellcheck disable=SC2193
-    if [ "${BOOTSTRAP_PROVIDER:-}" = "ec2" ]; then
-        if ! which aws >/dev/null 2>&1; then
-            sudo snap install aws-cli --classic || true
-        fi
-
-        mkdir -p "$HOME"/.aws
-        echo "[default]" > "$HOME"/.aws/credentials
-        cat "$HOME"/.local/share/juju/credentials.yaml |\
-            grep aws: -A 4 | grep key: |\
-            tail -2 |\
-            sed -e 's/      access-key:/aws_access_key_id =/' \
-                -e 's/      secret-key:/aws_secret_access_key =/' \
-            >> "$HOME"/.aws/credentials
-        echo -e "[default]\nregion = us-east-1" > "$HOME"/.aws/config
-        chmod 600 ~/.aws/*
-    fi
-    # shellcheck disable=SC2193
-    if [ "${BOOTSTRAP_PROVIDER:-}" = "azure" ]; then
-        if ! which az >/dev/null 2>&1; then
-            curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-        fi
-
-        az login --service-principal \
-          -u "$(cat "$HOME"/.local/share/juju/credentials.yaml | yq ".credentials.azure.credentials.application-id")" \
-          -p "$(cat "$HOME"/.local/share/juju/credentials.yaml | yq ".credentials.azure.credentials.application-password")" \
-          --tenant "${AZURE_TENANT}"
-    fi
     attempts=$((attempts + 1))
 done
 

--- a/jobs/ci-run/integration/gen/test-smoke.yml
+++ b/jobs/ci-run/integration/gen/test-smoke.yml
@@ -28,155 +28,17 @@
     - multijob:
         name: 'IntegrationTests-smoke'
         projects:
-        - name: 'test-smoke-test-build-aws'
-          current-parameters: true
-        - name: 'test-smoke-test-build-lxd'
-          current-parameters: true
         - name: 'test-smoke-test-deploy-aws'
           current-parameters: true
         - name: 'test-smoke-test-deploy-lxd'
           current-parameters: true
 
 - job:
-    name: test-smoke-test-build-aws
-    node: ephemeral-noble-8c-32g-amd64
-    concurrent: true
-    description: |-
-      Test test_build in smoke suite on aws
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{{7}}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'aws'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'ec2'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    - string:
-        default: 'us-east-1'
-        description: 'Cloud Region to use when bootstrapping Juju'
-        name: BOOTSTRAP_REGION
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - select-oci-registry
-      - wait-for-cloud-init
-      - prepare-integration-test
-      - run-integration-test:
-            test_name: 'smoke'
-            setup_steps: ''
-            task_name: 'test_build'
-            skip_tasks: 'test_deploy'
-    publishers:
-      - integration-artifacts
-
-- job:
-    name: test-smoke-test-build-lxd
-    node: ephemeral-noble-8c-32g-amd64
-    concurrent: true
-    description: |-
-      Test test_build in smoke suite on lxd
-    parameters:
-    - validating-string:
-        name: SHORT_GIT_COMMIT
-        description: 'Enable sub job to be run individually.'
-        regex: ^\S{{7}}$
-        msg: Enter a valid 7 char git sha
-    - choice:
-        default: 'amd64'
-        description: 'Build arch used to download the build tar.gz.'
-        name: BUILD_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used to boostrap controller.'
-        name: BOOTSTRAP_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - choice:
-        default: ''
-        description: 'Arch used for hosted models.'
-        name: MODEL_ARCH
-        choices:
-        - amd64
-        - arm64
-        - s390x
-        - ppc64el
-    - string:
-        default: 'localhost'
-        description: 'Cloud to use when bootstrapping Juju'
-        name: BOOTSTRAP_CLOUD
-    - string:
-        default: 'lxd'
-        description: 'Provider to use when bootstrapping Juju'
-        name: BOOTSTRAP_PROVIDER
-    wrappers:
-      - default-integration-test-wrapper
-      - timeout:
-          timeout: 30
-          fail: true
-          type: absolute
-    builders:
-      - select-oci-registry
-      - wait-for-cloud-init
-      - prepare-integration-test
-      - run-integration-test:
-            test_name: 'smoke'
-            setup_steps: ''
-            task_name: 'test_build'
-            skip_tasks: 'test_deploy'
-    publishers:
-      - integration-artifacts
-
-- job:
     name: test-smoke-test-deploy-aws
     node: ephemeral-noble-8c-32g-amd64
     concurrent: true
     description: |-
-      Test test_deploy in smoke suite on aws
+      Test smoke suite on aws
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -235,7 +97,7 @@
       - run-integration-test:
             test_name: 'smoke'
             setup_steps: ''
-            task_name: 'test_deploy'
+            task_name: ''
             skip_tasks: 'test_build'
     publishers:
       - integration-artifacts
@@ -245,7 +107,7 @@
     node: ephemeral-noble-8c-32g-amd64
     concurrent: true
     description: |-
-      Test test_deploy in smoke suite on lxd
+      Test smoke suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -300,7 +162,7 @@
       - run-integration-test:
             test_name: 'smoke'
             setup_steps: ''
-            task_name: 'test_deploy'
+            task_name: ''
             skip_tasks: 'test_build'
     publishers:
       - integration-artifacts

--- a/tools/gen-wire-tests/juju.config
+++ b/tools/gen-wire-tests/juju.config
@@ -234,3 +234,4 @@ folders:
   skip-subtasks:
     - test_pebble_change_updated
     - test_upgrade_simplestream_previous
+    - test_build


### PR DESCRIPTION
The test runner script had aws and azure specific setup which isn't needed.
The az cli is needed for one test - this should be installed by the test itself like other tests do for their dependencies. But for now use the proper builder step to get it.
We also skip so called ci tests which just build the source code, since we don't install go to run the ci tests any more.