### PR TITLE
docs: add mention of a required Github token for gen-wire-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ edit `./jobs/ci-run/integration/integrationtests.yml`.
 
 To build the job descriptions run:
 ```
+export GH_TOKEN=<your github token>
 JUJU_REPO_PATH="<juju-repo-on-branch-to-generate-jobs-from>" make gen-wire-tests
 ```
 


### PR DESCRIPTION
Mention that gen-wire-tests requires a Github token in the readme to avoid user to delve on code :)