### PR TITLE
chore: add the machines feature branch for merge

### DIFF
--- a/jobs/github/mergejobs.yaml
+++ b/jobs/github/mergejobs.yaml
@@ -69,6 +69,8 @@
           branch_name: 3.6
       - "feature-ssh":
           branch_name: feature/ssh
+      - "feature-machines":
+          branch_name: feature/machines
     jobs:
       - "github-juju-merge-jobs-{job_suffix}"
 


### PR DESCRIPTION
Small patch to add the /merge trigger on the PRs targetting the feature/machines branch.