### PR TITLE
chore: remove docker.io (no longer used) and fix jujud-operator build

### DIFF
--- a/jobs/ci-run/build/buildjuju.yml
+++ b/jobs/ci-run/build/buildjuju.yml
@@ -140,7 +140,7 @@
 - job:
     name: build-jujud-operator
     node: ephemeral-noble-16c-64g-amd64
-    description: Build juju docker image for caas operator on all platforms.
+    description: Build juju container image for caas operator on all platforms.
     wrappers:
       - ansicolor
       - workspace-cleanup
@@ -172,13 +172,12 @@
           set -eu
 
           touch build.properties
-          echo "DOCKER_USERNAME=public.ecr.aws/jujuqabot/build-${{SHORT_GIT_COMMIT}}" >> build.properties
+          echo "OCI_REGISTRY_USERNAME=public.ecr.aws/jujuqabot/build-${{SHORT_GIT_COMMIT}}" >> build.properties
 
           cat build.properties
       - inject:
           properties-file: build.properties
       - install-docker
-      - docker-login
       - ensure-aws-credentials
       - docker-ecr-login
       - get-s3-build-payload-packaging:

--- a/jobs/common/cloud-city.yml
+++ b/jobs/common/cloud-city.yml
@@ -41,14 +41,6 @@
           properties-file: $CLOUD_CITY/azuretoolsrc
 
 - builder:
-    name: "get-docker-creds"
-    builders:
-      - get-cloud-city-repo:
-          files: dockerrc
-      - inject:
-          properties-file: $CLOUD_CITY/dockerrc
-
-- builder:
     name: "get-ec2-creds"
     builders:
       - get-cloud-city-repo:

--- a/jobs/common/pre-reqs.yaml
+++ b/jobs/common/pre-reqs.yaml
@@ -13,21 +13,6 @@
     builders:
       - shell: !include-raw-verbatim: scripts/setup_steps-install-docker.sh
 
-# docker-login will run the login steps for connecting this host's docker daemon
-# to the Juju docker hub account.
-- builder:
-    name: docker-login
-    builders:
-      - get-docker-creds
-      - host-src-command:
-          src_command: |-
-            #!/bin/bash
-            set -eu
-            set +x
-
-            echo "Logging into Dockerhub with username ${{DOCKERHUB_U}}"
-            echo "$DOCKERHUB_P" | docker login -u "$DOCKERHUB_U" --password-stdin
-
 # docker-ecr-login will run the login steps for connecting this host's docker
 # to the Juju ecr public account.
 - builder:


### PR DESCRIPTION
We no longer publish to docker.io so remove that code.

Fix jujud operator builds -DOCKER_USERNAME should now be OCI_REGISTRY_USERNAME