### PR TITLE
fix: generate agent streams with content id 'testing'

### DIFF
--- a/jobs/ci-run/build/streams.yaml
+++ b/jobs/ci-run/build/streams.yaml
@@ -91,20 +91,9 @@
           dest: ${{WORKSPACE}}/agent/build-${{JUJU_VERSION}}-${{SHORT_GIT_COMMIT}}
           platforms: linux/amd64 linux/arm64
       - retrieve-generated-streams
-      - install-stream-patcher
       - shell: |-
           #!/bin/bash
           set -e
-
-          # Patch the index/product files so that all paths are namespaced by
-          # the build ID. Basically, we create the following folder structure:
-          # $root/
-          #  - builds/build-SHA
-          #    - streams/v1
-          #    - agents/*.tgz
-          ${{WORKSPACE}}/stream-patcher.py \
-            ${{WORKSPACE}}/streams \
-            ${{SHORT_GIT_COMMIT}}
 
           s3cmd sync --config $S3_CFG \
             ${{WORKSPACE}}/streams \
@@ -149,22 +138,10 @@
           dest: ${{WORKSPACE}}/agent/build-${{JUJU_VERSION}}-${{SHORT_GIT_COMMIT}}
           platforms: linux/amd64 linux/arm64
       - retrieve-generated-streams
-      - install-stream-patcher
       - get-azure-creds
       - shell: |-
           #!/bin/bash
           set -eu
-
-          # Patch the index/product files so that all paths are namespaced by
-          # the build ID. Basically, we create the following folder structure:
-          # $root/
-          #  - builds/build-SHA
-          #    - streams/v1
-          #    - agents/*.tgz
-          ${{WORKSPACE}}/stream-patcher.py \
-            ${{WORKSPACE}}/streams \
-            ${{SHORT_GIT_COMMIT}}
-
           set +x
           az storage blob upload-batch \
             --account-key=${{AZURE_STORAGE_ACCESS_KEY}} \
@@ -192,67 +169,3 @@
             s3://juju-qa-data/ci-run/build-${{SHORT_GIT_COMMIT}}/agents/${{GENERATED_STREAMS_TARBALL}} \
             ./
           tar xf ${{GENERATED_STREAMS_TARBALL}}
-
-- builder:
-    name: install-stream-patcher
-    builders:
-      - shell: |-
-          #!/bin/bash
-
-          # Create the stream product/index patching script on the fly
-
-          index_type="agents"
-          if [[ "${{JUJU_VERSION}}" == 2.8* ]]; then
-            index_type="tools"
-          fi
-
-          cat  <<EOT > ${{WORKSPACE}}/stream-patcher.py
-          #!/usr/bin/env python3
-
-          from argparse import ArgumentParser
-          from os import path
-          import collections.abc
-          import json
-          import sys
-
-
-          def main():
-              parser = ArgumentParser()
-              parser.add_argument(
-                  'stream_folder', help='The folder where the stream contents have been unpacked')
-              parser.add_argument(
-                  'build_sha', help='The short git SHA of the current build')
-              args = parser.parse_args()
-
-              rewrite_agent_paths(args.stream_folder, args.build_sha)
-
-          def rewrite_agent_paths(stream_folder, build_sha):
-              target = path.join(
-                  stream_folder,
-                  "v1",
-                  "com.ubuntu.juju-build-{{}}-${{index_type}}.json".format(build_sha)
-              )
-              with open(target) as f:
-                  stream_data = json.load(f)
-
-              stream_data = patch_agent_path_r(stream_data, stream_data, build_sha)
-              with open(target, 'w') as f:
-                  f.write(json.dumps(stream_data, indent=4))
-
-          def patch_agent_path_r(d, u, sha):
-              for k, v in u.items():
-                  if isinstance(v, collections.abc.Mapping):
-                      d[k] = patch_agent_path_r(d.get(k, {{}}), v, sha)
-                  elif isinstance(v, str):
-                      if "agent/build-" in v:
-                          d[k] = "agent/{{}}".format(
-                              str.lstrip(v, "agent/build-{{}}/".format(sha))
-                          )
-              return d
-
-
-          if __name__ == "__main__":
-              sys.exit(main())
-          EOT
-
-          chmod +x ${{WORKSPACE}}/stream-patcher.py

--- a/jobs/ci-run/scripts/generate-agent-json.template.sh
+++ b/jobs/ci-run/scripts/generate-agent-json.template.sh
@@ -4,7 +4,6 @@ set -e
 
 output_file_name="{output_dir}/build-${{JUJU_VERSION}}-${{SHORT_GIT_COMMIT}}-agent.json"
 
-content_id_part=build-${{SHORT_GIT_COMMIT}}
 version=${{JUJU_VERSION}}
 version_name=$(date +"%Y%m%d")
 
@@ -25,7 +24,6 @@ for platform in ${{platform_loop[@]}}; do
     os=$(echo "${{platform}}" | cut -f 1 -d '/')
 
     agent_loop=({product_name})
-    index_type="agents"
 
     agent_file_name="juju-${{JUJU_VERSION}}-${{os}}-${{arch}}.tgz"
     agent_file_md5_sum=$(md5sum ${{agent_file_name}} | awk '{{print $1}}')
@@ -40,7 +38,7 @@ for platform in ${{platform_loop[@]}}; do
       element=$(cat << EOF
 [{{
     "arch": "${{arch}}",
-    "content_id": "com.ubuntu.juju:${{content_id_part}}:${{index_type}}",
+    "content_id": "com.ubuntu.juju:testing:agents",
     "format": "products:1.0",
     "ftype": "tar.gz",
     "item_name": "${{item_name}}",


### PR DESCRIPTION
Generate the agent simplestreams metadata using the content id of "testing" rather than the commit sha.

We also no longer need the stream patching to occur so drop that code.