### PR TITLE
feat: enable debug mode for tests

### DIFF
--- a/jobs/github/mergejobs.yaml
+++ b/jobs/github/mergejobs.yaml
@@ -69,8 +69,6 @@
           branch_name: 3.6
       - "feature-ssh":
           branch_name: feature/ssh
-      - "feature-machines":
-          branch_name: feature/machines
     jobs:
       - "github-juju-merge-jobs-{job_suffix}"
 

--- a/jobs/github/scripts/snippet_build_check-juju-juju.sh
+++ b/jobs/github/scripts/snippet_build_check-juju-juju.sh
@@ -35,7 +35,7 @@ if [ "$(make -q race-test > /dev/null 2>&1 || echo $?)" -eq 2 ]; then
     go test -v -race ./... | tee ${WORKSPACE}/go-unittest.out
     check_exit=$?
 else
-    make race-test VERBOSE_CHECK=1 | tee ${WORKSPACE}/go-unittest.out
+    make race-test VERBOSE_CHECK=1 JUJU_DEBUG=1 | tee ${WORKSPACE}/go-unittest.out
     check_exit=$?
 fi
 set +o pipefail


### PR DESCRIPTION
When running tests, we sometimes see stack traces from dqlite, but we can't pass them on to the dqlite team, as we strip the symbols.

We should consider not stripping symbols in production, but that's another issue. Let's not hamstring ourselves.