### PR TITLE
fix: repair gce and azure cleanup scripts

### DIFF
--- a/jobs/common/pre-reqs.yaml
+++ b/jobs/common/pre-reqs.yaml
@@ -226,7 +226,7 @@
           set -xeu
 
           sudo DEBIAN_FRONTEND=noninteractive apt install -y python3-pip;
-          sudo pip3 install apache-libcloud;
+          sudo pip3 install apache-libcloud --break-system-packages;
 
 - builder:
     name: install-gce-libs
@@ -236,7 +236,7 @@
           set -xeu
 
           sudo DEBIAN_FRONTEND=noninteractive apt install -y python3-pip;
-          sudo pip3 install apache-libcloud;
+          sudo pip3 install apache-libcloud --break-system-packages;
 
 - builder:
     name: get-aws-cleanup-scripts

--- a/jobs/z-jobs/scripts/azure-cleanup.sh
+++ b/jobs/z-jobs/scripts/azure-cleanup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -eux
+
+if [ ! "$(which jq >/dev/null 2>&1)" ]; then
+  sudo snap install jq || true
+fi
+if [ ! "$(which yq >/dev/null 2>&1)" ]; then
+  sudo snap install yq || true
+fi
+
+az login --service-principal \
+  -u "$(cat "$CLOUD_CITY"/credentials.yaml | yq ".credentials.azure.credentials.application-id")" \
+  -p "$(cat "$CLOUD_CITY"/credentials.yaml | yq ".credentials.azure.credentials.application-password")" \
+  --tenant "$AZURE_TENANT"
+
+HOURS=3
+subscription_id=$(cat "$CLOUD_CITY"/credentials.yaml | yq ".credentials.azure.credentials.subscription-id")
+echo "cleaning subscription $subscription_id"
+az group list --subscription "$subscription_id" | jq -r '.[] | select(.id | contains("juju-")) | .name' | while read group ; do
+  oldest=$(az resource list --subscription "$subscription_id" --resource-group "$group" | jq -r 'map(select(.createdTime != null)) | map(.createdTime | split(".") | (.[0] + "Z") | fromdate) | sort | .[0]')
+  if [[ "$oldest" = "null" ]]; then
+    echo "skipping $group"
+    continue
+  fi
+  if [ $((($(date -u +%s)-$oldest)/3600)) -gt $HOURS ]; then
+    echo "deleting resource group $group"
+    az group delete --subscription "$subscription_id" --resource-group "$group" -f "Microsoft.Compute/virtualMachineScaleSets" -f "Microsoft.Compute/virtualMachines" -y
+  fi
+done

--- a/jobs/z-jobs/scripts/gce-cleanup.sh
+++ b/jobs/z-jobs/scripts/gce-cleanup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -eu
+
+# Display instances' regions
+python3 $SCRIPTS_DIR/gce.py -v list-instances juju-*
+
+python3 $SCRIPTS_DIR/gce.py -v delete-instances -o 2 juju-*
+
+gcloud auth activate-service-account --key-file=$GCE_CREDENTIALS_FILE
+gcloud config set project gothic-list-89514
+gcloud compute firewall-rules list
+
+# TODO - we no longer store state between jobs invocations.
+# We need a new way to delete stale filewall rules.
+
+# On every job run, remove any rules that still exist from last run
+# generate gce rules with
+# gcloud compute firewall-rules list | awk {'print $1'} | grep juju > ~/gcerules
+gcloud compute firewall-rules list | awk {'print $1'} | grep juju | sort -u > newrules
+# destroy all rules still found
+comm -1 -2  ~/gcerules newrules | xargs  -I % gcloud compute firewall-rules delete % --quiet
+# set new rules
+mv newrules ~/gcerules

--- a/jobs/z-jobs/z-clean-resources-azure.yml
+++ b/jobs/z-jobs/z-clean-resources-azure.yml
@@ -22,15 +22,17 @@
             --tenant "$AZURE_TENANT"
 
           HOURS=3
-          az group list --subscription "$AZURE_SUBSCRIPTION_ID" | jq -r '.[] | select(.id | contains("juju-")) | .name' | while read group ; do
-            oldest=$(az resource list --subscription "$AZURE_SUBSCRIPTION_ID" --resource-group "$group" | jq -r 'map(select(.createdTime != null)) | map(.createdTime | split(".") | (.[0] + "Z") | fromdate) | sort | .[0]')
+          subscription_id=$(cat "$CLOUD_CITY"/credentials.yaml | yq ".credentials.azure.credentials.subscription-id")
+          echo "cleaning subscription $subscription_id"
+          az group list --subscription "$subscription_id" | jq -r '.[] | select(.id | contains("juju-")) | .name' | while read group ; do
+            oldest=$(az resource list --subscription "$subscription_id" --resource-group "$group" | jq -r 'map(select(.createdTime != null)) | map(.createdTime | split(".") | (.[0] + "Z") | fromdate) | sort | .[0]')
             if [[ "$oldest" = "null" ]]; then
               echo "skipping $group"
               continue
             fi
             if [ $((($(date -u +%s)-$oldest)/3600)) -gt $HOURS ]; then
               echo "deleting resource group $group"
-              az group delete --subscription "$AZURE_SUBSCRIPTION_ID" --resource-group "$group" -f "Microsoft.Compute/virtualMachineScaleSets" -f "Microsoft.Compute/virtualMachines" -y
+              az group delete --subscription "$subscription_id" --resource-group "$group" -f "Microsoft.Compute/virtualMachineScaleSets" -f "Microsoft.Compute/virtualMachines" -y
             fi
           done
     description: |-

--- a/jobs/z-jobs/z-clean-resources-azure.yml
+++ b/jobs/z-jobs/z-clean-resources-azure.yml
@@ -5,36 +5,7 @@
       - install-azure-cli
       - get-azure-creds
       - get-juju-cloud-creds
-      - shell: |-
-          #!/bin/bash
-          set -eux
-
-          if [ ! "$(which jq >/dev/null 2>&1)" ]; then
-            sudo snap install jq || true
-          fi
-          if [ ! "$(which yq >/dev/null 2>&1)" ]; then
-            sudo snap install yq || true
-          fi
-
-          az login --service-principal \
-            -u "$(cat "$CLOUD_CITY"/credentials.yaml | yq ".credentials.azure.credentials.application-id")" \
-            -p "$(cat "$CLOUD_CITY"/credentials.yaml | yq ".credentials.azure.credentials.application-password")" \
-            --tenant "$AZURE_TENANT"
-
-          HOURS=3
-          subscription_id=$(cat "$CLOUD_CITY"/credentials.yaml | yq ".credentials.azure.credentials.subscription-id")
-          echo "cleaning subscription $subscription_id"
-          az group list --subscription "$subscription_id" | jq -r '.[] | select(.id | contains("juju-")) | .name' | while read group ; do
-            oldest=$(az resource list --subscription "$subscription_id" --resource-group "$group" | jq -r 'map(select(.createdTime != null)) | map(.createdTime | split(".") | (.[0] + "Z") | fromdate) | sort | .[0]')
-            if [[ "$oldest" = "null" ]]; then
-              echo "skipping $group"
-              continue
-            fi
-            if [ $((($(date -u +%s)-$oldest)/3600)) -gt $HOURS ]; then
-              echo "deleting resource group $group"
-              az group delete --subscription "$subscription_id" --resource-group "$group" -f "Microsoft.Compute/virtualMachineScaleSets" -f "Microsoft.Compute/virtualMachines" -y
-            fi
-          done
+      - shell: !include-raw-verbatim: scripts/azure-cleanup.sh
     description: |-
       Delete old azure resource groups.
     node: ephemeral-noble-small-amd64

--- a/jobs/z-jobs/z-clean-resources-gce.yml
+++ b/jobs/z-jobs/z-clean-resources-gce.yml
@@ -4,30 +4,7 @@
     builders:
       - get-gce-creds
       - get-gce-cleanup-scripts
-      - shell: |-
-          #!/bin/bash
-          set -eu
-
-          # Display instances' regions
-          python3 $SCRIPTS_DIR/gce.py -v list-instances juju-*
-
-          python3 $SCRIPTS_DIR/gce.py -v delete-instances -o 2 juju-*
-
-          gcloud auth activate-service-account --key-file=$GCE_CREDENTIALS_FILE
-          gcloud config set project gothic-list-89514
-          gcloud compute firewall-rules list
-
-          # TODO - we no longer store state between jobs invocations.
-          # We need a new way to delete stale filewall rules.
-
-          # On every job run, remove any rules that still exist from last run
-          # generate gce rules with
-          # gcloud compute firewall-rules list | awk {'print $1'} | grep juju > ~/gcerules
-          gcloud compute firewall-rules list | awk {'print $1'} | grep juju | sort -u > newrules
-          # destroy all rules still found
-          comm -1 -2  ~/gcerules newrules | xargs  -I % gcloud compute firewall-rules delete % --quiet
-          # set new rules
-          mv newrules ~/gcerules
+      - shell: !include-raw-verbatim: scripts/gce-cleanup.sh
     node: ephemeral-noble-small-amd64
     publishers:
       - email-ext:


### PR DESCRIPTION
The Azure and GCE cleanup scripts were broken.

Azure was using the wrong subscription-id.

GCE was unable to install Python deps and couldn't parse a awk command in YAML so the script was moved from YAML to a sh file.

