### PR TITLE
fix: install Mongo deps only when Juju < 4 in unit test script

### DIFF
--- a/jobs/ci-run/scripts/snippet_run-unit-tests.template.sh
+++ b/jobs/ci-run/scripts/snippet_run-unit-tests.template.sh
@@ -10,7 +10,11 @@ cd ${{JUJU_SRC_PATH}}
 # when running inside a privileged container, snapd fails because udevd isn't
 # running, but on the second occurance it is.
 # see: https://github.com/lxc/lxd/issues/4308
-make install-mongo-dependencies
+# also need check the Juju version, if < 4.0 then install mongo dependencies.
+JUJU_VERSION=$(juju version | cut -d. -f1)
+if [[ $JUJU_VERSION -lt 4 ]]; then
+  make install-mongo-dependencies
+fi
 make setup-lxd || true
 
 # Disable JS support as juju-mongodb doesn't support it.


### PR DESCRIPTION
- Add JUJU_VERSION check before running make install-mongo-dependencies
- Avoid unnecessary Mongo setup on Juju 4+