### PR TITLE
ci(dependencies): installs google-cloud-cli

### DIFF
--- a/jobs/ci-run/integration/common/test-runner.sh
+++ b/jobs/ci-run/integration/common/test-runner.sh
@@ -63,6 +63,9 @@ while [ $attempts -lt 3 ]; do
     if ! which microceph >/dev/null 2>&1; then
         sudo snap install microceph || true
     fi
+    if ! which gcloud >/dev/null 2>&1; then
+        sudo snap install google-cloud-cli --classic || true
+    fi
     attempts=$((attempts + 1))
 done
 


### PR DESCRIPTION
Installs the google-cloud-cli snap if gcloud binary is missing.