### PR TITLE
test(microk8s-version): bump microk8s version to 1.34

### DIFF
--- a/jobs/ci-run/integration/builders.yaml
+++ b/jobs/ci-run/integration/builders.yaml
@@ -25,7 +25,7 @@
     name: run-integration-test-microk8s
     builders:
       - install-microk8s:
-          channel: "1.33/stable"
+          channel: "1.34/stable"
       - select-oci-registry
       - get-s3-build-payload-testing:
           SHORT_GIT_COMMIT: "${{SHORT_GIT_COMMIT}}"


### PR DESCRIPTION
# Description

bump microk8s version to 1.34 because Ubuntu 24.04 and higher have introduced a change in apparmor rules that broke the strict microk8s snap. See https://github.com/canonical/microk8s/issues/5190. This problem shouldn't not be present with non strict snaps, which we are using here. However the failures I am seeing are very similar to ones related to AppArmon (juju fails to even create the namespace to bootstrap the controller). So this is a test to see if 1.34 will solve the issue.

Similar to https://github.com/juju/juju/pull/20697