### PR TITLE
chore: rename OCI_REGISTRY_USERNAME to PUSH_OCI_REGISTRY

### DIFF
--- a/jobs/ci-run/build/buildjuju.yml
+++ b/jobs/ci-run/build/buildjuju.yml
@@ -172,7 +172,7 @@
           set -eu
 
           touch build.properties
-          echo "OCI_REGISTRY_USERNAME=public.ecr.aws/jujuqabot/build-${{SHORT_GIT_COMMIT}}" >> build.properties
+          echo "PUSH_OCI_REGISTRY=public.ecr.aws/jujuqabot/build-${{SHORT_GIT_COMMIT}}" >> build.properties
 
           cat build.properties
       - inject:


### PR DESCRIPTION
Juju now uses PUSH_OCI_REGISTRY so update the jujud operator build to use it instead of OCI_REGISTRY_USERNAME