### PR TITLE
chore: increase timeout for controllercharm bash test

### DIFF
--- a/jobs/ci-run/integration/gen/test-controllercharm.yml
+++ b/jobs/ci-run/integration/gen/test-controllercharm.yml
@@ -83,7 +83,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 60
           fail: true
           type: absolute
     builders:
@@ -157,7 +157,7 @@
     wrappers:
       - default-integration-test-wrapper
       - timeout:
-          timeout: 30
+          timeout: 60
           fail: true
           type: absolute
     builders:

--- a/tools/gen-wire-tests/juju.config
+++ b/tools/gen-wire-tests/juju.config
@@ -100,6 +100,8 @@ folders:
   timeout:
     cloud_azure:
       test_managed_identity: 60
+    controllercharm:
+      test_prometheus: 60
     network:
       test_network_health_azure: 45
     secrets_iaas:


### PR DESCRIPTION
Test run fails consistently in both `3.6` and `4.0` runs due to timeout for
microk8s runs because microk8s setup takes a long time and doesn't leave enough
time to run for the tests.

Relates to https://github.com/juju/juju/issues/22336
