### PR TITLE
ci: add automatic QA PS7 Jenkins sync

### DIFF
--- a/.github/workflows/push-jenkins.yml
+++ b/.github/workflows/push-jenkins.yml
@@ -1,0 +1,43 @@
+name: "Push Jenkins Jobs"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - jobs/common/**
+      - jobs/ci-run/**
+      - Makefile
+      - requirements.txt
+      - constraint.txt
+      - jenkins_jobs_ps7.ini
+      - .github/workflows/push-jenkins.yml
+  workflow_dispatch:
+
+concurrency:
+  group: push-qa-ps7-jenkins-jobs
+  cancel-in-progress: false
+
+jobs:
+  push:
+    name: Push jobs to QA PS7 Jenkins
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Push jobs
+        env:
+          JENKINS_USER: ${{ secrets.JENKINS_PS7_USER }}
+          JENKINS_ACCESS_TOKEN: ${{ secrets.JENKINS_PS7_ACCESS_TOKEN }}
+          STATIC_ANALYSIS_JOB: test_static_analysis_shell
+          JJB_CONF_PATH: ./jenkins_jobs_ps7.ini
+        run: |
+          set -euxo pipefail
+          make push
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -28,8 +28,21 @@ make gen-wire-tests
 
 ## Uploading to Jenkins
 
-To push, you need to be on the Canonical VPN and have your authentication token ready. If you don't have any, create an
-[API Token on jenkins](https://www.jenkins.io/doc/book/system-administration/authenticating-scripted-clients/)
+Changes merged into `main` are automatically synced to
+[QA PS7 Jenkins](https://jenkins-juju-qa-ps7.jenkins.canonical.com/k8s-jenkins-juju-qa-ps7-server-jenkins-k8s/)
+through GitHub Actions.
+
+The automatic sync workflow requires these repository secrets:
+
+- `JENKINS_PS7_USER`: the Jenkins username related to the API key
+- `JENKINS_PS7_ACCESS_TOKEN`: the Jenkins API key
+
+The current QA Jenkins at https://jenkins.juju.canonical.com/ is still synced
+manually.
+
+To push manually, you need to be on the Canonical VPN and have your
+authentication token ready. If you don't have any, create an
+[API Token on Jenkins](https://www.jenkins.io/doc/book/system-administration/authenticating-scripted-clients/).
 
 Then setup the environment variables:
 
@@ -48,6 +61,12 @@ And push to https://jenkins.juju.canonical.com/ with:
 
 ```bash
 make push
+```
+
+To manually push to https://jenkins-juju-qa-ps7.jenkins.canonical.com/k8s-jenkins-juju-qa-ps7-server-jenkins-k8s/ instead:
+
+```bash
+JJB_CONF_PATH=./jenkins_jobs_ps7.ini make push
 ```
 
 ## Run on Noble 24.04

--- a/jenkins_jobs_ps7.ini
+++ b/jenkins_jobs_ps7.ini
@@ -1,0 +1,11 @@
+[job_builder]
+ignore_cache=True
+keep_descriptions=False
+include_path=.:scripts:~/git/
+recursive=False
+exclude=.*:manual:./development
+allow_duplicates=False
+
+[jenkins]
+url=https://jenkins-juju-qa-ps7.jenkins.canonical.com/k8s-jenkins-juju-qa-ps7-server-jenkins-k8s/
+query_plugins_info=True

--- a/jobs/ci-run/integration/gen/test-cli.yml
+++ b/jobs/ci-run/integration/gen/test-cli.yml
@@ -30,6 +30,8 @@
         projects:
         - name: 'test-cli-test-block-commands-lxd'
           current-parameters: true
+        - name: 'test-cli-test-diff-bundle-lxd'
+          current-parameters: true
         - name: 'test-cli-test-display-clouds-lxd'
           current-parameters: true
         - name: 'test-cli-test-local-charms-lxd'
@@ -114,7 +116,82 @@
                   test_name: 'cli'
                   setup_steps: ''
                   task_name: 'test_block_commands'
-                  skip_tasks: 'test_display_clouds,test_local_charms,test_model_config,test_model_constraints,test_model_defaults,test_unregister'
+                  skip_tasks: 'test_diff_bundle,test_display_clouds,test_local_charms,test_model_config,test_model_constraints,test_model_defaults,test_unregister'
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-cli-test-diff-bundle-lxd
+    node: ephemeral-noble-8c-32g-amd64
+    concurrent: true
+    description: |-
+      Test test_diff_bundle in cli suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{{7}}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'localhost'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - common
+      - select-oci-registry
+      - prepare-integration-test
+      - conditional-step:
+          # Only run on regexp version match.
+          # Accounts for tests which do not exist
+          # until a given Juju version.
+          condition-kind: regex-match
+          # Matches Juju >= 3.6; task introduced in that version.
+          regex: "^[4-9].*|^3\\.([6-9]|\\d{{2,}})(\\.|-).*"
+          label: "${{JUJU_VERSION}}"
+          on-evaluation-failure: "dont-run"
+          steps:
+            - run-integration-test:
+                  test_name: 'cli'
+                  setup_steps: ''
+                  task_name: 'test_diff_bundle'
+                  skip_tasks: 'test_block_commands,test_display_clouds,test_local_charms,test_model_config,test_model_constraints,test_model_defaults,test_unregister'
     publishers:
       - integration-artifacts
 
@@ -179,7 +256,7 @@
             test_name: 'cli'
             setup_steps: ''
             task_name: 'test_display_clouds'
-            skip_tasks: 'test_block_commands,test_local_charms,test_model_config,test_model_constraints,test_model_defaults,test_unregister'
+            skip_tasks: 'test_block_commands,test_diff_bundle,test_local_charms,test_model_config,test_model_constraints,test_model_defaults,test_unregister'
     publishers:
       - integration-artifacts
 
@@ -244,7 +321,7 @@
             test_name: 'cli'
             setup_steps: ''
             task_name: 'test_local_charms'
-            skip_tasks: 'test_block_commands,test_display_clouds,test_model_config,test_model_constraints,test_model_defaults,test_unregister'
+            skip_tasks: 'test_block_commands,test_diff_bundle,test_display_clouds,test_model_config,test_model_constraints,test_model_defaults,test_unregister'
     publishers:
       - integration-artifacts
 
@@ -309,7 +386,7 @@
             test_name: 'cli'
             setup_steps: ''
             task_name: 'test_model_config'
-            skip_tasks: 'test_block_commands,test_display_clouds,test_local_charms,test_model_constraints,test_model_defaults,test_unregister'
+            skip_tasks: 'test_block_commands,test_diff_bundle,test_display_clouds,test_local_charms,test_model_constraints,test_model_defaults,test_unregister'
     publishers:
       - integration-artifacts
 
@@ -374,7 +451,7 @@
             test_name: 'cli'
             setup_steps: ''
             task_name: 'test_model_constraints'
-            skip_tasks: 'test_block_commands,test_display_clouds,test_local_charms,test_model_config,test_model_defaults,test_unregister'
+            skip_tasks: 'test_block_commands,test_diff_bundle,test_display_clouds,test_local_charms,test_model_config,test_model_defaults,test_unregister'
     publishers:
       - integration-artifacts
 
@@ -439,7 +516,7 @@
             test_name: 'cli'
             setup_steps: ''
             task_name: 'test_model_defaults'
-            skip_tasks: 'test_block_commands,test_display_clouds,test_local_charms,test_model_config,test_model_constraints,test_unregister'
+            skip_tasks: 'test_block_commands,test_diff_bundle,test_display_clouds,test_local_charms,test_model_config,test_model_constraints,test_unregister'
     publishers:
       - integration-artifacts
 
@@ -504,6 +581,6 @@
             test_name: 'cli'
             setup_steps: ''
             task_name: 'test_unregister'
-            skip_tasks: 'test_block_commands,test_display_clouds,test_local_charms,test_model_config,test_model_constraints,test_model_defaults'
+            skip_tasks: 'test_block_commands,test_diff_bundle,test_display_clouds,test_local_charms,test_model_config,test_model_constraints,test_model_defaults'
     publishers:
       - integration-artifacts

--- a/jobs/ci-run/integration/gen/test-cloud_gce.yml
+++ b/jobs/ci-run/integration/gen/test-cloud_gce.yml
@@ -41,6 +41,8 @@
                 current-parameters: true
               - name: 'test-cloud_gce-test-pro-images-google'
                 current-parameters: true
+              - name: 'test-cloud_gce-test-root-disk-source-google'
+                current-parameters: true
               - name: 'test-cloud_gce-test-serviceaccount-credential-google'
                 current-parameters: true
 
@@ -109,7 +111,7 @@
             test_name: 'cloud_gce'
             setup_steps: ''
             task_name: 'test_create_storage_pool'
-            skip_tasks: 'test_deploy_gpu_instance,test_pro_images,test_serviceaccount_credential'
+            skip_tasks: 'test_deploy_gpu_instance,test_pro_images,test_root_disk_source,test_serviceaccount_credential'
     publishers:
       - integration-artifacts
 
@@ -178,7 +180,7 @@
             test_name: 'cloud_gce'
             setup_steps: ''
             task_name: 'test_deploy_gpu_instance'
-            skip_tasks: 'test_create_storage_pool,test_pro_images,test_serviceaccount_credential'
+            skip_tasks: 'test_create_storage_pool,test_pro_images,test_root_disk_source,test_serviceaccount_credential'
     publishers:
       - integration-artifacts
 
@@ -247,7 +249,76 @@
             test_name: 'cloud_gce'
             setup_steps: ''
             task_name: 'test_pro_images'
-            skip_tasks: 'test_create_storage_pool,test_deploy_gpu_instance,test_serviceaccount_credential'
+            skip_tasks: 'test_create_storage_pool,test_deploy_gpu_instance,test_root_disk_source,test_serviceaccount_credential'
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-cloud_gce-test-root-disk-source-google
+    node: ephemeral-noble-small-amd64
+    concurrent: true
+    description: |-
+      Test test_root_disk_source in cloud_gce suite on google
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{{7}}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'google'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'gce'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - common
+      - select-oci-registry
+      - prepare-integration-test
+      - run-integration-test:
+            test_name: 'cloud_gce'
+            setup_steps: ''
+            task_name: 'test_root_disk_source'
+            skip_tasks: 'test_create_storage_pool,test_deploy_gpu_instance,test_pro_images,test_serviceaccount_credential'
     publishers:
       - integration-artifacts
 
@@ -316,6 +387,6 @@
             test_name: 'cloud_gce'
             setup_steps: ''
             task_name: 'test_serviceaccount_credential'
-            skip_tasks: 'test_create_storage_pool,test_deploy_gpu_instance,test_pro_images'
+            skip_tasks: 'test_create_storage_pool,test_deploy_gpu_instance,test_pro_images,test_root_disk_source'
     publishers:
       - integration-artifacts

--- a/jobs/ci-run/integration/gen/test-machine.yml
+++ b/jobs/ci-run/integration/gen/test-machine.yml
@@ -32,13 +32,17 @@
           current-parameters: true
         - name: 'test-machine-test-logs-lxd'
           current-parameters: true
+        - name: 'test-machine-test-provisioning-info-aws'
+          current-parameters: true
+        - name: 'test-machine-test-provisioning-info-lxd'
+          current-parameters: true
 
 - job:
     name: test-machine-test-logs-aws
     node: ephemeral-noble-small-amd64
     concurrent: true
     description: |-
-      Test machine suite on aws
+      Test test_logs in machine suite on aws
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -97,8 +101,8 @@
       - run-integration-test:
             test_name: 'machine'
             setup_steps: ''
-            task_name: ''
-            skip_tasks: ''
+            task_name: 'test_logs'
+            skip_tasks: 'test_provisioning_info'
     publishers:
       - integration-artifacts
 
@@ -107,7 +111,7 @@
     node: ephemeral-noble-8c-32g-amd64
     concurrent: true
     description: |-
-      Test machine suite on lxd
+      Test test_logs in machine suite on lxd
     parameters:
     - validating-string:
         name: SHORT_GIT_COMMIT
@@ -162,7 +166,161 @@
       - run-integration-test:
             test_name: 'machine'
             setup_steps: ''
-            task_name: ''
-            skip_tasks: ''
+            task_name: 'test_logs'
+            skip_tasks: 'test_provisioning_info'
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-machine-test-provisioning-info-aws
+    node: ephemeral-noble-small-amd64
+    concurrent: true
+    description: |-
+      Test test_provisioning_info in machine suite on aws
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{{7}}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'aws'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'ec2'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    - string:
+        default: 'us-east-1'
+        description: 'Cloud Region to use when bootstrapping Juju'
+        name: BOOTSTRAP_REGION
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - common
+      - select-oci-registry
+      - prepare-integration-test
+      - conditional-step:
+          # Only run on regexp version match.
+          # Accounts for tests which do not exist
+          # until a given Juju version.
+          condition-kind: regex-match
+          # Matches Juju >= 4.0; task introduced in that version.
+          regex: "^[5-9].*|^4\\.([0-9]|\\d{{2,}})(\\.|-).*"
+          label: "${{JUJU_VERSION}}"
+          on-evaluation-failure: "dont-run"
+          steps:
+            - run-integration-test:
+                  test_name: 'machine'
+                  setup_steps: ''
+                  task_name: 'test_provisioning_info'
+                  skip_tasks: 'test_logs'
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-machine-test-provisioning-info-lxd
+    node: ephemeral-noble-8c-32g-amd64
+    concurrent: true
+    description: |-
+      Test test_provisioning_info in machine suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{{7}}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'localhost'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - common
+      - select-oci-registry
+      - prepare-integration-test
+      - conditional-step:
+          # Only run on regexp version match.
+          # Accounts for tests which do not exist
+          # until a given Juju version.
+          condition-kind: regex-match
+          # Matches Juju >= 4.0; task introduced in that version.
+          regex: "^[5-9].*|^4\\.([0-9]|\\d{{2,}})(\\.|-).*"
+          label: "${{JUJU_VERSION}}"
+          on-evaluation-failure: "dont-run"
+          steps:
+            - run-integration-test:
+                  test_name: 'machine'
+                  setup_steps: ''
+                  task_name: 'test_provisioning_info'
+                  skip_tasks: 'test_logs'
     publishers:
       - integration-artifacts

--- a/jobs/ci-run/integration/gen/test-manual.yml
+++ b/jobs/ci-run/integration/gen/test-manual.yml
@@ -25,17 +25,27 @@
     builders:
     - get-s3-build-details
     - set-test-description
-    - multijob:
-        name: 'IntegrationTests-manual'
-        projects:
-        - name: 'test-manual-test-deploy-manual-aws'
-          current-parameters: true
-        - name: 'test-manual-test-deploy-manual-lxd'
-          current-parameters: true
-        - name: 'test-manual-test-spaces-manual-aws'
-          current-parameters: true
-        - name: 'test-manual-test-spaces-manual-lxd'
-          current-parameters: true
+    - conditional-step:
+        condition-kind: not
+        condition-operand:
+          condition-kind: regex-match
+          # Matches Juju >= 4.0; negated above to skip
+          # versions from 4.0 onward (suite removed in that version).
+          regex: "^[5-9].*|^4\\.([0-9]|\\d{{2,}})(\\.|-).*"
+          label: "${{JUJU_VERSION}}"
+        on-evaluation-failure: "dont-run"
+        steps:
+          - multijob:
+              name: 'IntegrationTests-manual'
+              projects:
+              - name: 'test-manual-test-deploy-manual-aws'
+                current-parameters: true
+              - name: 'test-manual-test-deploy-manual-lxd'
+                current-parameters: true
+              - name: 'test-manual-test-spaces-manual-aws'
+                current-parameters: true
+              - name: 'test-manual-test-spaces-manual-lxd'
+                current-parameters: true
 
 - job:
     name: test-manual-test-deploy-manual-aws

--- a/jobs/ci-run/integration/gen/test-secrets_iaas.yml
+++ b/jobs/ci-run/integration/gen/test-secrets_iaas.yml
@@ -39,6 +39,8 @@
                 current-parameters: true
               - name: 'test-secrets_iaas-test-secret-drain-lxd'
                 current-parameters: true
+              - name: 'test-secrets_iaas-test-secret-nonleader-unit-owned-lxd'
+                current-parameters: true
               - name: 'test-secrets_iaas-test-secrets-cmr-lxd'
                 current-parameters: true
               - name: 'test-secrets_iaas-test-secrets-juju-lxd'
@@ -111,7 +113,7 @@
             test_name: 'secrets_iaas'
             setup_steps: ''
             task_name: 'test_obsolete_revisions'
-            skip_tasks: 'test_secret_drain,test_secrets_cmr,test_secrets_juju,test_secrets_k8s,test_secrets_vault,test_user_secret_drain'
+            skip_tasks: 'test_secret_drain,test_secret_nonleader_unit_owned,test_secrets_cmr,test_secrets_juju,test_secrets_k8s,test_secrets_vault,test_user_secret_drain'
     publishers:
       - integration-artifacts
 
@@ -176,7 +178,82 @@
             test_name: 'secrets_iaas'
             setup_steps: ''
             task_name: 'test_secret_drain'
-            skip_tasks: 'test_obsolete_revisions,test_secrets_cmr,test_secrets_juju,test_secrets_k8s,test_secrets_vault,test_user_secret_drain'
+            skip_tasks: 'test_obsolete_revisions,test_secret_nonleader_unit_owned,test_secrets_cmr,test_secrets_juju,test_secrets_k8s,test_secrets_vault,test_user_secret_drain'
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-secrets_iaas-test-secret-nonleader-unit-owned-lxd
+    node: ephemeral-noble-8c-32g-amd64
+    concurrent: true
+    description: |-
+      Test test_secret_nonleader_unit_owned in secrets_iaas suite on lxd
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{{7}}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'localhost'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'lxd'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - common
+      - select-oci-registry
+      - prepare-integration-test
+      - conditional-step:
+          # Only run on regexp version match.
+          # Accounts for tests which do not exist
+          # until a given Juju version.
+          condition-kind: regex-match
+          # Matches Juju >= 4.0; task introduced in that version.
+          regex: "^[5-9].*|^4\\.([0-9]|\\d{{2,}})(\\.|-).*"
+          label: "${{JUJU_VERSION}}"
+          on-evaluation-failure: "dont-run"
+          steps:
+            - run-integration-test:
+                  test_name: 'secrets_iaas'
+                  setup_steps: ''
+                  task_name: 'test_secret_nonleader_unit_owned'
+                  skip_tasks: 'test_obsolete_revisions,test_secret_drain,test_secrets_cmr,test_secrets_juju,test_secrets_k8s,test_secrets_vault,test_user_secret_drain'
     publishers:
       - integration-artifacts
 
@@ -241,7 +318,7 @@
             test_name: 'secrets_iaas'
             setup_steps: ''
             task_name: 'test_secrets_cmr'
-            skip_tasks: 'test_obsolete_revisions,test_secret_drain,test_secrets_juju,test_secrets_k8s,test_secrets_vault,test_user_secret_drain'
+            skip_tasks: 'test_obsolete_revisions,test_secret_drain,test_secret_nonleader_unit_owned,test_secrets_juju,test_secrets_k8s,test_secrets_vault,test_user_secret_drain'
     publishers:
       - integration-artifacts
 
@@ -306,7 +383,7 @@
             test_name: 'secrets_iaas'
             setup_steps: ''
             task_name: 'test_secrets_juju'
-            skip_tasks: 'test_obsolete_revisions,test_secret_drain,test_secrets_cmr,test_secrets_k8s,test_secrets_vault,test_user_secret_drain'
+            skip_tasks: 'test_obsolete_revisions,test_secret_drain,test_secret_nonleader_unit_owned,test_secrets_cmr,test_secrets_k8s,test_secrets_vault,test_user_secret_drain'
     publishers:
       - integration-artifacts
 
@@ -371,7 +448,7 @@
             test_name: 'secrets_iaas'
             setup_steps: ''
             task_name: 'test_secrets_k8s'
-            skip_tasks: 'test_obsolete_revisions,test_secret_drain,test_secrets_cmr,test_secrets_juju,test_secrets_vault,test_user_secret_drain'
+            skip_tasks: 'test_obsolete_revisions,test_secret_drain,test_secret_nonleader_unit_owned,test_secrets_cmr,test_secrets_juju,test_secrets_vault,test_user_secret_drain'
     publishers:
       - integration-artifacts
 
@@ -436,7 +513,7 @@
             test_name: 'secrets_iaas'
             setup_steps: ''
             task_name: 'test_secrets_vault'
-            skip_tasks: 'test_obsolete_revisions,test_secret_drain,test_secrets_cmr,test_secrets_juju,test_secrets_k8s,test_user_secret_drain'
+            skip_tasks: 'test_obsolete_revisions,test_secret_drain,test_secret_nonleader_unit_owned,test_secrets_cmr,test_secrets_juju,test_secrets_k8s,test_user_secret_drain'
     publishers:
       - integration-artifacts
 
@@ -501,6 +578,6 @@
             test_name: 'secrets_iaas'
             setup_steps: ''
             task_name: 'test_user_secret_drain'
-            skip_tasks: 'test_obsolete_revisions,test_secret_drain,test_secrets_cmr,test_secrets_juju,test_secrets_k8s,test_secrets_vault'
+            skip_tasks: 'test_obsolete_revisions,test_secret_drain,test_secret_nonleader_unit_owned,test_secrets_cmr,test_secrets_juju,test_secrets_k8s,test_secrets_vault'
     publishers:
       - integration-artifacts

--- a/jobs/ci-run/integration/gen/test-secrets_k8s.yml
+++ b/jobs/ci-run/integration/gen/test-secrets_k8s.yml
@@ -41,6 +41,8 @@
                 current-parameters: true
               - name: 'test-secrets_k8s-test-secrets-microk8s'
                 current-parameters: true
+              - name: 'test-secrets_k8s-test-secrets-cmr-microk8s'
+                current-parameters: true
               - name: 'test-secrets_k8s-test-user-secret-drain-microk8s'
                 current-parameters: true
               - name: 'test-secrets_k8s-test-user-secrets-microk8s'
@@ -107,7 +109,7 @@
             test_name: 'secrets_k8s'
             setup_steps: ''
             task_name: 'test_add_multiple_secrets_parallel'
-            skip_tasks: 'test_secret_drain,test_secrets,test_user_secret_drain,test_user_secrets'
+            skip_tasks: 'test_secret_drain,test_secrets,test_secrets_cmr,test_user_secret_drain,test_user_secrets'
     publishers:
       - integration-artifacts
 
@@ -172,7 +174,7 @@
             test_name: 'secrets_k8s'
             setup_steps: ''
             task_name: 'test_secret_drain'
-            skip_tasks: 'test_add_multiple_secrets_parallel,test_secrets,test_user_secret_drain,test_user_secrets'
+            skip_tasks: 'test_add_multiple_secrets_parallel,test_secrets,test_secrets_cmr,test_user_secret_drain,test_user_secrets'
     publishers:
       - integration-artifacts
 
@@ -237,7 +239,72 @@
             test_name: 'secrets_k8s'
             setup_steps: ''
             task_name: 'test_secrets'
-            skip_tasks: 'test_add_multiple_secrets_parallel,test_secret_drain,test_user_secret_drain,test_user_secrets'
+            skip_tasks: 'test_add_multiple_secrets_parallel,test_secret_drain,test_secrets_cmr,test_user_secret_drain,test_user_secrets'
+    publishers:
+      - integration-artifacts
+
+- job:
+    name: test-secrets_k8s-test-secrets-cmr-microk8s
+    node: ephemeral-noble-8c-32g-amd64
+    concurrent: true
+    description: |-
+      Test test_secrets_cmr in secrets_k8s suite on microk8s
+    parameters:
+    - validating-string:
+        name: SHORT_GIT_COMMIT
+        description: 'Enable sub job to be run individually.'
+        regex: ^\S{{7}}$
+        msg: Enter a valid 7 char git sha
+    - choice:
+        default: 'amd64'
+        description: 'Build arch used to download the build tar.gz.'
+        name: BUILD_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used to boostrap controller.'
+        name: BOOTSTRAP_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - choice:
+        default: ''
+        description: 'Arch used for hosted models.'
+        name: MODEL_ARCH
+        choices:
+        - amd64
+        - arm64
+        - s390x
+        - ppc64el
+    - string:
+        default: 'microk8s'
+        description: 'Cloud to use when bootstrapping Juju'
+        name: BOOTSTRAP_CLOUD
+    - string:
+        default: 'k8s'
+        description: 'Provider to use when bootstrapping Juju'
+        name: BOOTSTRAP_PROVIDER
+    wrappers:
+      - default-integration-test-wrapper
+      - timeout:
+          timeout: 30
+          fail: true
+          type: absolute
+    builders:
+      - common
+      - select-oci-registry
+      - prepare-integration-test
+      - run-integration-test-microk8s:
+            test_name: 'secrets_k8s'
+            setup_steps: ''
+            task_name: 'test_secrets_cmr'
+            skip_tasks: 'test_add_multiple_secrets_parallel,test_secret_drain,test_secrets,test_user_secret_drain,test_user_secrets'
     publishers:
       - integration-artifacts
 
@@ -302,7 +369,7 @@
             test_name: 'secrets_k8s'
             setup_steps: ''
             task_name: 'test_user_secret_drain'
-            skip_tasks: 'test_add_multiple_secrets_parallel,test_secret_drain,test_secrets,test_user_secrets'
+            skip_tasks: 'test_add_multiple_secrets_parallel,test_secret_drain,test_secrets,test_secrets_cmr,test_user_secrets'
     publishers:
       - integration-artifacts
 
@@ -367,6 +434,6 @@
             test_name: 'secrets_k8s'
             setup_steps: ''
             task_name: 'test_user_secrets'
-            skip_tasks: 'test_add_multiple_secrets_parallel,test_secret_drain,test_secrets,test_user_secret_drain'
+            skip_tasks: 'test_add_multiple_secrets_parallel,test_secret_drain,test_secrets,test_secrets_cmr,test_user_secret_drain'
     publishers:
       - integration-artifacts

--- a/tests/suites/static_analysis/lint_yaml.sh
+++ b/tests/suites/static_analysis/lint_yaml.sh
@@ -38,6 +38,7 @@ files:
   skip:
     - .github/workflows/static-analysis.yml
     - .github/workflows/local-deployment.yml
+    - .github/workflows/push-jenkins.yml
     - yamlfmt.yaml
     - tools/gen-wire-tests/2.9.yaml
     - tools/gen-wire-tests/3.6.yaml
@@ -97,6 +98,7 @@ files:
   skip:
     - .github/workflows/static-analysis.yml
     - .github/workflows/local-deployment.yml
+    - .github/workflows/push-jenkins.yml
     - jobs/ci-run/integration/gen/*
     - yamlfmt.yaml
     - tools/gen-wire-tests/2.9.yaml
@@ -143,6 +145,7 @@ files:
   skip:
     - .github/workflows/static-analysis.yml
     - .github/workflows/local-deployment.yml
+    - .github/workflows/push-jenkins.yml
     - yamlfmt.yaml
     - tools/gen-wire-tests/2.9.yaml
     - tools/gen-wire-tests/3.6.yaml

--- a/tools/gen-wire-tests/3.6.yaml
+++ b/tools/gen-wire-tests/3.6.yaml
@@ -117,6 +117,7 @@ suites:
   - test_relation_list_app
   - test_relation_model_get
   resources:
+  - test_attach_resources
   - test_basic_resources
   - test_container_resources
   - test_upgrade_resources
@@ -133,6 +134,7 @@ suites:
   - test_secret_drain
   - test_secrets
   - test_secrets_cmr
+  - test_secrets_token_reuse
   - test_user_secret_drain
   - test_user_secrets
   sidecar:
@@ -170,6 +172,7 @@ suites:
   - test_add_unit_attach_storage
   - test_add_unit_attach_storage_scaling_race_condition
   - test_add_unit_duplicate_pvc_exists
+  - test_deleted_pvc_recreated_with_new_storage
   - test_deploy_attach_storage
   - test_force_import_filesystem
   - test_import_filesystem

--- a/tools/gen-wire-tests/4.0.yaml
+++ b/tools/gen-wire-tests/4.0.yaml
@@ -24,6 +24,7 @@ suites:
   - test_deploy_ck
   cli:
   - test_block_commands
+  - test_diff_bundle
   - test_display_clouds
   - test_local_charms
   - test_model_config
@@ -37,6 +38,7 @@ suites:
   - test_create_storage_pool
   - test_deploy_gpu_instance
   - test_pro_images
+  - test_root_disk_source
   - test_serviceaccount_credential
   cmr:
   - test_offer_consume
@@ -88,9 +90,7 @@ suites:
   - test_deploy_kubeflow
   machine:
   - test_logs
-  manual:
-  - test_deploy_manual
-  - test_spaces_manual
+  - test_provisioning_info
   model:
   - test_model_config
   - test_model_destroy
@@ -121,15 +121,18 @@ suites:
   secrets_iaas:
   - test_obsolete_revisions
   - test_secret_drain
+  - test_secret_nonleader_unit_owned
   - test_secrets_cmr
   - test_secrets_juju
   - test_secrets_k8s
   - test_secrets_vault
+  - test_track_latest_revision
   - test_user_secret_drain
   secrets_k8s:
   - test_add_multiple_secrets_parallel
   - test_secret_drain
   - test_secrets
+  - test_secrets_cmr
   - test_user_secret_drain
   - test_user_secrets
   sidecar:

--- a/tools/gen-wire-tests/main.yaml
+++ b/tools/gen-wire-tests/main.yaml
@@ -24,6 +24,7 @@ suites:
   - test_deploy_ck
   cli:
   - test_block_commands
+  - test_diff_bundle
   - test_display_clouds
   - test_local_charms
   - test_model_config
@@ -37,6 +38,7 @@ suites:
   - test_create_storage_pool
   - test_deploy_gpu_instance
   - test_pro_images
+  - test_root_disk_source
   - test_serviceaccount_credential
   cmr:
   - test_offer_consume
@@ -88,9 +90,7 @@ suites:
   - test_deploy_kubeflow
   machine:
   - test_logs
-  manual:
-  - test_deploy_manual
-  - test_spaces_manual
+  - test_provisioning_info
   model:
   - test_model_config
   - test_model_destroy
@@ -121,6 +121,7 @@ suites:
   secrets_iaas:
   - test_obsolete_revisions
   - test_secret_drain
+  - test_secret_nonleader_unit_owned
   - test_secrets_cmr
   - test_secrets_juju
   - test_secrets_k8s
@@ -130,6 +131,7 @@ suites:
   - test_add_multiple_secrets_parallel
   - test_secret_drain
   - test_secrets
+  - test_secrets_cmr
   - test_user_secret_drain
   - test_user_secrets
   sidecar:


### PR DESCRIPTION
Add a GitHub Actions workflow that pushes ci-run Jenkins jobs to the QA PS7 Jenkins instance when relevant changes merge to main.

Add a committed JJB config for the QA PS7 endpoint while keeping the current QA Jenkins instance as a manual sync target. Document the required PS7 Jenkins secrets and exclude the new workflow from the custom YAML static-analysis checks.