### PR TITLE
feat(ci): split gating-tests into per-branch chains

### DIFF
--- a/jobs/ci-run/ci-run-gating-tests.yml
+++ b/jobs/ci-run/ci-run-gating-tests.yml
@@ -44,23 +44,23 @@
             - name: gating-integration-tests-arm64
               current-parameters: true
 
-# Per-branch gating chains. The un-suffixed "gating-tests" job above remains as
-# the catch-all chain for feature branches and manual runs; the jobs below give
+# Per-branch gating jobs. The un-suffixed "gating-tests" job above remains as
+# the generic job for feature branches and manual runs; the jobs below give
 # each maintained branch its own build history and trend.
 - project:
-    name: "gating-tests-branch-chains"
-    job_suffix:
+    name: "branch-gating-tests"
+    job_branch:
       - "2.9"
       - "3.6"
       - "4.0"
       - "main"
     jobs:
-      - "gating-tests-{job_suffix}"
+      - "gating-tests-{job_branch}"
 
 - job-template:
-    name: "gating-tests-{job_suffix}"
+    name: "gating-tests-{job_branch}"
     project-type: "multijob"
-    description: "Run gating tests for a Juju commit on the {job_suffix} branch"
+    description: "Run gating tests for a Juju commit on the {job_branch} branch"
     condition: SUCCESSFUL
     node: noop-parent-jobs
     concurrent: true

--- a/jobs/ci-run/ci-run-gating-tests.yml
+++ b/jobs/ci-run/ci-run-gating-tests.yml
@@ -43,3 +43,68 @@
               current-parameters: true
             - name: gating-integration-tests-arm64
               current-parameters: true
+
+# Per-branch gating chains. The un-suffixed "gating-tests" job above remains as
+# the catch-all chain for feature branches and manual runs; the jobs below give
+# each maintained branch its own build history and trend.
+- project:
+    name: "gating-tests-branch-chains"
+    job_suffix:
+      - "2.9"
+      - "3.6"
+      - "4.0"
+      - "main"
+    jobs:
+      - "gating-tests-{job_suffix}"
+
+- job-template:
+    name: "gating-tests-{job_suffix}"
+    project-type: "multijob"
+    description: "Run gating tests for a Juju commit on the {job_suffix} branch"
+    condition: SUCCESSFUL
+    node: noop-parent-jobs
+    concurrent: true
+    wrappers:
+      - ansicolor
+      - workspace-cleanup
+      - timestamps
+      - timeout:
+          timeout: 300
+          fail: true
+          type: absolute
+    properties:
+      - build-discarder:
+          days-to-keep: 30
+          num-to-keep: 50
+          artifact-days-to-keep: 30
+          artifact-num-to-keep: 50
+    parameters:
+      - validating-string:
+          description: The git short hash for the commit you wish to test
+          name: SHORT_GIT_COMMIT
+          regex: ^\S{{7}}$
+          msg: Enter a valid 7 char git sha
+    publishers:
+      - email-ext:
+          recipients: juju-crew@lists.canonical.com
+          content-type: html
+          attach-build-log: true
+          first-failure: true
+          fixed-unhealthy: true
+          subject: "STOP THE LINE!"
+          body: |
+            <h1>functional-tests-amd64 test failure</h1>
+            These tests must pass. Diagnose the problem and assign to a member of the team today!
+            <br>
+            $DEFAULT_CONTENT
+    builders:
+      - get-s3-build-details
+      - set-test-description
+      - multijob:
+          name: GatingTests
+          # Defining BUILD_ARCH ensures the right binaries are pulled down.
+          projects:
+            - name: gating-integration-tests-amd64
+              current-parameters: true
+            - name: gating-integration-tests-arm64
+              current-parameters: true

--- a/jobs/ci-run/ci-run-master.yml
+++ b/jobs/ci-run/ci-run-master.yml
@@ -103,7 +103,7 @@
       - string:
           name: GITHUB_BRANCH_NAME
           default: ""
-          description: "Branch the commit belongs to. Used to route gating tests to the per-branch chain. Empty routes to the catch-all chain."
+          description: "Used to select the correct downstream gating test job to run. Empty values select the generic gating test job."
     builders:
       - resolve-git-sha
       - detect-commit-go-version
@@ -177,12 +177,12 @@
               current-parameters: true
               predefined-parameters: |-
                 SHORT_GIT_COMMIT=${{SHORT_GIT_COMMIT}}
-      # Route gating tests to the per-branch chain matching GITHUB_BRANCH_NAME.
+      # Select the downstream gating test job matching GITHUB_BRANCH_NAME.
       # These steps run last, so they only execute when all build phases passed
       # (matching the old "condition: SUCCESS" publisher behaviour).
       # Anything that is not a maintained branch (feature branches, manual
-      # builds, private-repo triggers) falls through to the catch-all
-      # ci-gating-tests chain.
+      # builds, private-repo triggers) falls through to the generic
+      # ci-gating-tests job.
       - conditional-step:
           condition-kind: strings-match
           condition-string1: "$GITHUB_BRANCH_NAME"
@@ -284,25 +284,25 @@
             predefined-parameters: |-
               SHORT_GIT_COMMIT=${{SHORT_GIT_COMMIT}}
 
-# Per-branch gating chains. The un-suffixed "ci-gating-tests" job above remains
-# as the catch-all chain for feature branches and manual runs; the jobs below
+# Per-branch gating jobs. The un-suffixed "ci-gating-tests" job above remains
+# as the generic job for feature branches and manual runs; the jobs below
 # give each maintained branch its own build history and trend.
 - project:
-    name: "ci-gating-tests-branch-chains"
-    job_suffix:
+    name: "ci-branch-gating-tests"
+    job_branch:
       - "2.9"
       - "3.6"
       - "4.0"
       - "main"
     jobs:
-      - "ci-gating-tests-{job_suffix}"
+      - "ci-gating-tests-{job_branch}"
 
 - job-template:
-    name: "ci-gating-tests-{job_suffix}"
+    name: "ci-gating-tests-{job_branch}"
     disabled: false
     concurrent: false
     description: |
-      These tests are required to be all green before a Juju {job_suffix}
+      These tests are required to be all green before a Juju {job_branch}
       release is blessed for release.
     project-type: "multijob"
     node: noop-parent-jobs
@@ -334,7 +334,7 @@
           name: "Testing"
           condition: SUCCESSFUL
           projects:
-            - name: gating-tests-{job_suffix}
+            - name: gating-tests-{job_branch}
               current-parameters: true
               predefined-parameters: |-
                 SHORT_GIT_COMMIT=${{SHORT_GIT_COMMIT}}

--- a/jobs/ci-run/ci-run-master.yml
+++ b/jobs/ci-run/ci-run-master.yml
@@ -49,6 +49,7 @@
             predefined-parameters: |-
               GITHUB_REPO=juju/juju
               GITHUB_BRANCH_HEAD_SHA=${{GITHUB_BRANCH_HEAD_SHA}}
+              GITHUB_BRANCH_NAME=${{GITHUB_BRANCH_NAME}}
 
 - job:
     name: "ci-build-juju"
@@ -99,6 +100,10 @@
           name: GITHUB_BRANCH_HEAD_SHA
           default: ""
           description: "Specific git SHA to build (used to overwrite triggered runs)."
+      - string:
+          name: GITHUB_BRANCH_NAME
+          default: ""
+          description: "Branch the commit belongs to. Used to route gating tests to the per-branch chain. Empty routes to the catch-all chain."
     builders:
       - resolve-git-sha
       - detect-commit-go-version
@@ -172,13 +177,66 @@
               current-parameters: true
               predefined-parameters: |-
                 SHORT_GIT_COMMIT=${{SHORT_GIT_COMMIT}}
-    publishers:
-      - trigger-parameterized-builds:
-          - project: "ci-gating-tests"
-            condition: SUCCESS
-            current-parameters: true
-            predefined-parameters: |-
-              SHORT_GIT_COMMIT=${{SHORT_GIT_COMMIT}}
+      # Route gating tests to the per-branch chain matching GITHUB_BRANCH_NAME.
+      # These steps run last, so they only execute when all build phases passed
+      # (matching the old "condition: SUCCESS" publisher behaviour).
+      # Anything that is not a maintained branch (feature branches, manual
+      # builds, private-repo triggers) falls through to the catch-all
+      # ci-gating-tests chain.
+      - conditional-step:
+          condition-kind: strings-match
+          condition-string1: "$GITHUB_BRANCH_NAME"
+          condition-string2: "2.9"
+          condition-case-insensitive: false
+          steps:
+            - trigger-builds:
+                - project: "ci-gating-tests-2.9"
+                  current-parameters: true
+                  predefined-parameters: |-
+                    SHORT_GIT_COMMIT=${{SHORT_GIT_COMMIT}}
+      - conditional-step:
+          condition-kind: strings-match
+          condition-string1: "$GITHUB_BRANCH_NAME"
+          condition-string2: "3.6"
+          condition-case-insensitive: false
+          steps:
+            - trigger-builds:
+                - project: "ci-gating-tests-3.6"
+                  current-parameters: true
+                  predefined-parameters: |-
+                    SHORT_GIT_COMMIT=${{SHORT_GIT_COMMIT}}
+      - conditional-step:
+          condition-kind: strings-match
+          condition-string1: "$GITHUB_BRANCH_NAME"
+          condition-string2: "4.0"
+          condition-case-insensitive: false
+          steps:
+            - trigger-builds:
+                - project: "ci-gating-tests-4.0"
+                  current-parameters: true
+                  predefined-parameters: |-
+                    SHORT_GIT_COMMIT=${{SHORT_GIT_COMMIT}}
+      - conditional-step:
+          condition-kind: strings-match
+          condition-string1: "$GITHUB_BRANCH_NAME"
+          condition-string2: "main"
+          condition-case-insensitive: false
+          steps:
+            - trigger-builds:
+                - project: "ci-gating-tests-main"
+                  current-parameters: true
+                  predefined-parameters: |-
+                    SHORT_GIT_COMMIT=${{SHORT_GIT_COMMIT}}
+      - conditional-step:
+          condition-kind: regex-match
+          regex: '^(?!2\.9$|3\.6$|4\.0$|main$).*$'
+          label: "$GITHUB_BRANCH_NAME"
+          steps:
+            - trigger-builds:
+                - project: "ci-gating-tests"
+                  current-parameters: true
+                  predefined-parameters: |-
+                    SHORT_GIT_COMMIT=${{SHORT_GIT_COMMIT}}
 - job:
     name: "ci-gating-tests"
     disabled: false
@@ -211,6 +269,72 @@
           condition: SUCCESSFUL
           projects:
             - name: gating-tests
+              current-parameters: true
+              predefined-parameters: |-
+                SHORT_GIT_COMMIT=${{SHORT_GIT_COMMIT}}
+            - name: unit-tests
+              current-parameters: true
+              predefined-parameters: |-
+                SHORT_GIT_COMMIT=${{SHORT_GIT_COMMIT}}
+    publishers:
+      - trigger-parameterized-builds:
+          - project: "analyse-juju-tics"
+            condition: SUCCESS
+            current-parameters: true
+            predefined-parameters: |-
+              SHORT_GIT_COMMIT=${{SHORT_GIT_COMMIT}}
+
+# Per-branch gating chains. The un-suffixed "ci-gating-tests" job above remains
+# as the catch-all chain for feature branches and manual runs; the jobs below
+# give each maintained branch its own build history and trend.
+- project:
+    name: "ci-gating-tests-branch-chains"
+    job_suffix:
+      - "2.9"
+      - "3.6"
+      - "4.0"
+      - "main"
+    jobs:
+      - "ci-gating-tests-{job_suffix}"
+
+- job-template:
+    name: "ci-gating-tests-{job_suffix}"
+    disabled: false
+    concurrent: false
+    description: |
+      These tests are required to be all green before a Juju {job_suffix}
+      release is blessed for release.
+    project-type: "multijob"
+    node: noop-parent-jobs
+    wrappers:
+      - ansicolor
+      - workspace-cleanup
+      - timestamps
+      # Give ci-run 20 hours to complete.
+      - timeout:
+          timeout: 1200
+          fail: true
+          type: absolute
+    properties:
+      - build-discarder:
+          days-to-keep: 30
+          num-to-keep: 50
+          artifact-days-to-keep: 30
+          artifact-num-to-keep: 50
+    parameters:
+      - validating-string:
+          name: SHORT_GIT_COMMIT
+          description: The git short hash for the commit you wish to test
+          regex: ^\S{{7}}$
+          msg: Enter a valid 7 char git sha
+    builders:
+      - get-s3-build-details
+      - set-test-description
+      - multijob:
+          name: "Testing"
+          condition: SUCCESSFUL
+          projects:
+            - name: gating-tests-{job_suffix}
               current-parameters: true
               predefined-parameters: |-
                 SHORT_GIT_COMMIT=${{SHORT_GIT_COMMIT}}

--- a/jobs/ci-run/views.yml
+++ b/jobs/ci-run/views.yml
@@ -12,8 +12,8 @@
     name: "gating-tests"
     view-type: list
     # Explicit job list, frozen to keep this umbrella view identical to its
-    # historical contents for outside automation. Per-branch gating jobs live
-    # in their own views below and must NOT appear here.
+    # historical contents for outside automation. Branch-specific gating jobs
+    # live in their own views below and must NOT appear here.
     job-name:
       - gating-functional-tests-ppc64el
       - gating-functional-tests-s390x

--- a/jobs/ci-run/views.yml
+++ b/jobs/ci-run/views.yml
@@ -11,7 +11,35 @@
 - view:
     name: "gating-tests"
     view-type: list
-    regex: "gating-.*"
+    # Explicit job list, frozen to keep this umbrella view identical to its
+    # historical contents for outside automation. Per-branch gating jobs live
+    # in their own views below and must NOT appear here.
+    job-name:
+      - gating-functional-tests-ppc64el
+      - gating-functional-tests-s390x
+      - gating-integration-tests-amd64
+      - gating-integration-tests-arm64
+      - gating-tests
+
+- view:
+    name: "gating-tests-2.9"
+    view-type: list
+    regex: '.*gating-tests-2\.9.*'
+
+- view:
+    name: "gating-tests-3.6"
+    view-type: list
+    regex: '.*gating-tests-3\.6.*'
+
+- view:
+    name: "gating-tests-4.0"
+    view-type: list
+    regex: '.*gating-tests-4\.0.*'
+
+- view:
+    name: "gating-tests-main"
+    view-type: list
+    regex: '.*gating-tests-main.*'
 
 - view:
     name: "github-jobs"

--- a/tests/suites/static_analysis/lint_yaml.sh
+++ b/tests/suites/static_analysis/lint_yaml.sh
@@ -51,6 +51,8 @@ jobs:
     - ci-trigger-github-com-juju-juju
     - ci-build-juju
     - ci-gating-tests
+    - ci-gating-tests-branch-chains
+    - gating-tests-branch-chains
     - clean-workspaces
     - run-build-check-lxd
     - github-juju-check-jobs

--- a/tests/suites/static_analysis/lint_yaml.sh
+++ b/tests/suites/static_analysis/lint_yaml.sh
@@ -51,8 +51,8 @@ jobs:
     - ci-trigger-github-com-juju-juju
     - ci-build-juju
     - ci-gating-tests
-    - ci-gating-tests-branch-chains
-    - gating-tests-branch-chains
+    - ci-branch-gating-tests
+    - branch-gating-tests
     - clean-workspaces
     - run-build-check-lxd
     - github-juju-check-jobs


### PR DESCRIPTION
## Problem

The `gating-tests` chain (trigger → `ci-build-juju` → `ci-gating-tests` → `gating-tests`) mixes builds from all maintained branches (2.9.x, 3.6.x, 4.0.x, 4.1.x/main) **and feature branches** into a single build history, so per-branch trends are meaningless. Jenkins views select *jobs*, not *builds*, so the only way to get per-branch trends is per-branch chains.

## Change

- **Per-branch chains**: new JJB `project` + `job-template` pairs generating `ci-gating-tests-{2.9,3.6,4.0,main}` and `gating-tests-{2.9,3.6,4.0,main}`. Everything below stays shared (`gating-integration-tests-{amd64,arm64}`, `test-*-multijob`, leaf jobs, `unit-tests`, `analyse-juju-tics`) — it is commit-keyed and already concurrent.
- **Routing**: `ci-trigger-github-com-juju-juju` now passes `GITHUB_BRANCH_NAME` down; `ci-build-juju` gains the parameter and routes each build via mutually-exclusive `conditional-step` entries (exact match on 2.9/3.6/4.0/main → branch chain; regex negative-lookahead catch-all → existing jobs). Exactly one downstream fires per build — no execution multiplication.
- **Catch-all**: the existing un-suffixed `ci-gating-tests`/`gating-tests` jobs are untouched and keep their full history; they serve feature branches, manual runs, and the two hand-managed private triggers (which pass no branch name → empty → catch-all, i.e. today's behaviour).
- **Views**: the `gating-tests` umbrella view is frozen to an explicit list of its current 5 jobs so outside automation sees zero change; 4 new per-branch views are added; `ci-runs` is left dynamic.
- **Hygiene**: the 8 new jobs get a build discarder (30d/50 builds, per `tiobe.yml` precedent). Existing jobs untouched.

## Validation

- `make build-xml` and full `make tests` pass (shellcheck, yaml check, deadcode, simplify, alphabetise).
- Rendered XML diff of `gating-tests-2.9` vs `gating-tests` and `ci-gating-tests-2.9` vs `ci-gating-tests`: byte-identical except description + build-discarder.
- Umbrella view renders with `<jobNames>` = exactly today's 5 jobs, no `includeRegex`.
- Routing regex verified for all cases (exact branches, empty, `feature/*`, `2.9-security`, `main2`).

## Rollback

Revert the `ci-build-juju` routing steps and re-push; everything else is additive.

## Follow-ups (not in scope)

- When a `4.1` branch is cut: add the suffix to both project blocks + one `conditional-step` (~15 lines). When 2.9 goes EOL: delete 2 jobs + 1 view.
- Optional: hand-edit the 2 non-JJB private triggers to pass `GITHUB_BRANCH_NAME` for precise routing.
- Optional: per-branch `STOP THE LINE!` email policy (e.g. mute for main while 4.1 is unreleased).